### PR TITLE
0.0.3 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,10 @@ mkpfs pack folder [-h] [--adjust-output-file-extension | --no-adjust-output-file
                   [--compress | --no-compress] [--threshold-gain THRESHOLD_GAIN]
                   [--block-size BLOCK_SIZE] [--version {PS4,PS5}] [--inode-bits {32,64}]
                   [--case-sensitive | --case-insensitive] [--cpu-count CPU_COUNT]
-                  [--compression-level COMPRESSION_LEVEL] [--signed] [--encrypted]
+                  [--compression-level COMPRESSION_LEVEL]
+                  [--max-compressed-ratio MAX_COMPRESSED_RATIO]
+                  [--min-compress-size MIN_COMPRESS_SIZE]
+                  [--skip-executable-compression] [--signed] [--encrypted]
                   [--ekpfs-key EKPFS_KEY] [--require-game-files] [--verbose]
                   [--dry-run] [--verify] source_dir image_file
 ```
@@ -167,6 +170,17 @@ mkpfs pack folder ./input ./game.ffpfs --encrypted
 mkpfs pack folder ./input ./game.ffpfs --require-game-files --verify
 ```
 
+PowerShell example with tuned PFSC compression:
+
+```powershell
+python -m mkpfs pack folder c:\game_folder d:\game.ffpfs `
+  --compress `
+  --skip-executable-compression `
+  --compression-level 9 `
+  --max-compressed-ratio 95 `
+  --min-compress-size 65536
+```
+
 | Parameter | Description |
 | --- | --- |
 | `source_dir` | Source app or homebrew folder to pack. |
@@ -177,13 +191,16 @@ mkpfs pack folder ./input ./game.ffpfs --require-game-files --verify
 | `--compress` | Enable PFSC block compression. This is the default. |
 | `--no-compress` | Disable PFSC block compression. |
 | `--threshold-gain THRESHOLD_GAIN` | Minimum per-block gain percent required to keep PFSC-compressed blocks. Default: `20`. |
-| `--block-size BLOCK_SIZE` | PFS block size in bytes, or `auto`. Default: `auto`, which resolves to `65536`. |
+| `--block-size BLOCK_SIZE` | PFS block size in bytes, `auto`, or `auto-fit`. Default: `auto`, which resolves to `65536`; `auto-fit` picks 4096..65536 by estimated file-data padding. |
 | `--version {PS4,PS5}` | PFS profile version. Default: `PS4`. |
 | `--inode-bits {32,64}` | Inode width mode bit. Default: `32`. |
 | `--case-sensitive` | Build a case-sensitive image. |
 | `--case-insensitive` | Set the case-insensitive mode bit. This is the default behavior. |
 | `--cpu-count CPU_COUNT` | Number of CPU cores to use for PFSC compression. `0` means auto `max(1, cpu_count())`, non-zero uses `max(1, user value)`. |
 | `--compression-level COMPRESSION_LEVEL` | Zlib compression level from `0` to `9`. Default: `7`. |
+| `--max-compressed-ratio MAX_COMPRESSED_RATIO` | Maximum PFSC size as percent of the raw file size. Use `95` to store files raw unless PFSC is 95% of raw size or smaller. Default: disabled. |
+| `--min-compress-size MIN_COMPRESS_SIZE` | Store files smaller than this many bytes raw without trying PFSC compression. Use `65536` to skip files smaller than one PFSC logical block. Default: `0`. |
+| `--skip-executable-compression` | Store `eboot*.bin`, `*.prx`, and `*.sprx` files raw even when PFSC compression is enabled. |
 | `--signed` | Build a signed PFS image using a zero EKPFS key and seed. |
 | `--encrypted` | Encrypt filesystem blocks with AES-XTS. |
 | `--ekpfs-key EKPFS_KEY` | Optional 64-hex EKPFS key. When omitted with `--encrypted`, MkPFS uses an all-zero key. |
@@ -205,7 +222,10 @@ mkpfs pack file [-h] [--adjust-output-file-extension | --no-adjust-output-file-e
                 [--compress | --no-compress] [--threshold-gain THRESHOLD_GAIN]
                 [--block-size BLOCK_SIZE] [--version {PS4,PS5}] [--inode-bits {32,64}]
                 [--case-sensitive | --case-insensitive] [--cpu-count CPU_COUNT]
-                [--compression-level COMPRESSION_LEVEL] [--signed] [--encrypted]
+                [--compression-level COMPRESSION_LEVEL]
+                [--max-compressed-ratio MAX_COMPRESSED_RATIO]
+                [--min-compress-size MIN_COMPRESS_SIZE]
+                [--skip-executable-compression] [--signed] [--encrypted]
                 [--ekpfs-key EKPFS_KEY] [--verbose] [--dry-run] [--verify]
                 source_file image_file
 ```
@@ -227,13 +247,16 @@ mkpfs pack file ./payload.exfat ./payload.ffpfsc --verify
 | `--compress` | Enable PFSC block compression. This is the default. |
 | `--no-compress` | Disable PFSC block compression. |
 | `--threshold-gain THRESHOLD_GAIN` | Minimum per-block gain percent required to keep PFSC-compressed blocks. Default: `20`. |
-| `--block-size BLOCK_SIZE` | PFS block size in bytes, or `auto`. Default: `auto`, which resolves to `65536`. |
+| `--block-size BLOCK_SIZE` | PFS block size in bytes, `auto`, or `auto-fit`. Default: `auto`, which resolves to `65536`; `auto-fit` picks 4096..65536 by estimated file-data padding. |
 | `--version {PS4,PS5}` | PFS profile version. Default: `PS4`. |
 | `--inode-bits {32,64}` | Inode width mode bit. Default: `32`. |
 | `--case-sensitive` | Build a case-sensitive image. |
 | `--case-insensitive` | Set the case-insensitive mode bit. This is the default behavior. |
 | `--cpu-count CPU_COUNT` | Number of CPU cores to use for PFSC compression. `0` means auto `max(1, cpu_count())`, non-zero uses `max(1, user value)`. |
 | `--compression-level COMPRESSION_LEVEL` | Zlib compression level from `0` to `9`. Default: `7`. |
+| `--max-compressed-ratio MAX_COMPRESSED_RATIO` | Maximum PFSC size as percent of the raw file size. Use `95` to store files raw unless PFSC is 95% of raw size or smaller. Default: disabled. |
+| `--min-compress-size MIN_COMPRESS_SIZE` | Store files smaller than this many bytes raw without trying PFSC compression. Use `65536` to skip files smaller than one PFSC logical block. Default: `0`. |
+| `--skip-executable-compression` | Store `eboot*.bin`, `*.prx`, and `*.sprx` files raw even when PFSC compression is enabled. |
 | `--signed` | Build a signed PFS image using a zero EKPFS key and seed. |
 | `--encrypted` | Encrypt filesystem blocks with AES-XTS. |
 | `--ekpfs-key EKPFS_KEY` | Optional 64-hex EKPFS key. When omitted with `--encrypted`, MkPFS uses an all-zero key. |
@@ -400,7 +423,7 @@ Build Summary
     Compressed files:       53
     Uncompressed files:     127
     Actual gain achieved:   45.40%
-    Max theoretical gain:   46.51%  (3.14 GB if all files compressed)
+    All-PFSC gain:          46.51%  (3.14 GB if every file used PFSC)
 
   Block Alignment Waste:
     Block size:             64 KiB (65,536 bytes)

--- a/README.md
+++ b/README.md
@@ -190,17 +190,17 @@ python -m mkpfs pack folder c:\game_folder d:\game.ffpfs `
 | `--no-adjust-output-file-extension` | Keep the requested output file name unchanged. |
 | `--compress` | Enable PFSC block compression. This is the default. |
 | `--no-compress` | Disable PFSC block compression. |
-| `--threshold-gain THRESHOLD_GAIN` | Minimum per-block gain percent required to keep PFSC-compressed blocks. Default: `20`. |
+| `--threshold-gain THRESHOLD_GAIN` | Minimum per-block gain percent required to keep PFSC-compressed blocks. Default: `0`. |
 | `--block-size BLOCK_SIZE` | PFS block size in bytes, `auto`, or `auto-fit`. Default: `auto`, which resolves to `65536`; `auto-fit` picks 4096..65536 by estimated file-data padding. |
 | `--version {PS4,PS5}` | PFS profile version. Default: `PS4`. |
-| `--inode-bits {32,64}` | Inode width mode bit. Default: `32`. |
+| `--inode-bits {32,64}` | Inode width mode bit. Default: `64`. |
 | `--case-sensitive` | Build a case-sensitive image. |
 | `--case-insensitive` | Set the case-insensitive mode bit. This is the default behavior. |
 | `--cpu-count CPU_COUNT` | Number of CPU cores to use for PFSC compression. `0` means auto `max(1, cpu_count())`, non-zero uses `max(1, user value)`. |
-| `--compression-level COMPRESSION_LEVEL` | Zlib compression level from `0` to `9`. Default: `7`. |
+| `--compression-level COMPRESSION_LEVEL` | Zlib compression level from `0` to `9`. Default: `9`. |
 | `--max-compressed-ratio MAX_COMPRESSED_RATIO` | Maximum PFSC size as percent of the raw file size. Use `95` to store files raw unless PFSC is 95% of raw size or smaller. Default: disabled. |
 | `--min-compress-size MIN_COMPRESS_SIZE` | Store files smaller than this many bytes raw without trying PFSC compression. Use `65536` to skip files smaller than one PFSC logical block. Default: `0`. |
-| `--skip-executable-compression` | Store `eboot*.bin`, `*.prx`, and `*.sprx` files raw even when PFSC compression is enabled. |
+| `--skip-executable-compression` | Store `eboot*.bin`, `*.prx`, and `*.sprx` files raw even when PFSC compression is enabled. Default: enabled. |
 | `--signed` | Build a signed PFS image using a zero EKPFS key and seed. |
 | `--encrypted` | Encrypt filesystem blocks with AES-XTS. |
 | `--ekpfs-key EKPFS_KEY` | Optional 64-hex EKPFS key. When omitted with `--encrypted`, MkPFS uses an all-zero key. |
@@ -246,17 +246,17 @@ mkpfs pack file ./payload.exfat ./payload.ffpfsc --verify
 | `--no-adjust-output-file-extension` | Keep the requested output file name unchanged. |
 | `--compress` | Enable PFSC block compression. This is the default. |
 | `--no-compress` | Disable PFSC block compression. |
-| `--threshold-gain THRESHOLD_GAIN` | Minimum per-block gain percent required to keep PFSC-compressed blocks. Default: `20`. |
+| `--threshold-gain THRESHOLD_GAIN` | Minimum per-block gain percent required to keep PFSC-compressed blocks. Default: `0`. |
 | `--block-size BLOCK_SIZE` | PFS block size in bytes, `auto`, or `auto-fit`. Default: `auto`, which resolves to `65536`; `auto-fit` picks 4096..65536 by estimated file-data padding. |
 | `--version {PS4,PS5}` | PFS profile version. Default: `PS4`. |
-| `--inode-bits {32,64}` | Inode width mode bit. Default: `32`. |
+| `--inode-bits {32,64}` | Inode width mode bit. Default: `64`. |
 | `--case-sensitive` | Build a case-sensitive image. |
 | `--case-insensitive` | Set the case-insensitive mode bit. This is the default behavior. |
 | `--cpu-count CPU_COUNT` | Number of CPU cores to use for PFSC compression. `0` means auto `max(1, cpu_count())`, non-zero uses `max(1, user value)`. |
-| `--compression-level COMPRESSION_LEVEL` | Zlib compression level from `0` to `9`. Default: `7`. |
+| `--compression-level COMPRESSION_LEVEL` | Zlib compression level from `0` to `9`. Default: `9`. |
 | `--max-compressed-ratio MAX_COMPRESSED_RATIO` | Maximum PFSC size as percent of the raw file size. Use `95` to store files raw unless PFSC is 95% of raw size or smaller. Default: disabled. |
 | `--min-compress-size MIN_COMPRESS_SIZE` | Store files smaller than this many bytes raw without trying PFSC compression. Use `65536` to skip files smaller than one PFSC logical block. Default: `0`. |
-| `--skip-executable-compression` | Store `eboot*.bin`, `*.prx`, and `*.sprx` files raw even when PFSC compression is enabled. |
+| `--skip-executable-compression` | Store `eboot*.bin`, `*.prx`, and `*.sprx` files raw even when PFSC compression is enabled. Default: enabled. |
 | `--signed` | Build a signed PFS image using a zero EKPFS key and seed. |
 | `--encrypted` | Encrypt filesystem blocks with AES-XTS. |
 | `--ekpfs-key EKPFS_KEY` | Optional 64-hex EKPFS key. When omitted with `--encrypted`, MkPFS uses an all-zero key. |
@@ -385,10 +385,10 @@ PFS Image Builder - Parameters
   Header magic:      PFS (20130315)
   Compression Setup: PFSC (0x43534650)
   Block size:        65,536 bytes (64 KiB)
-  Inode width:       32-bit
-  PFS mode:          0x0008  (Bit 0=signed, Bit 1=64-bit inodes, Bit 2=encrypted, Bit 3=case insensitive)
+  Inode width:       64-bit
+  PFS mode:          0x000A  (Bit 0=signed, Bit 1=64-bit inodes, Bit 2=encrypted, Bit 3=case insensitive)
     Signed:          no
-    64-bit inodes:   no
+    64-bit inodes:   yes
     Encrypted:       no
     New crypt:       no
     Case insensitive: yes
@@ -442,9 +442,9 @@ Version:               1 (PS4)
 Header magic:          PFS (20130315)
 Compression Setup:     PFSC (0x43534650)
 Read-only:             yes
-Mode:                  0x0008  (Bit 0=signed, Bit 1=64-bit inodes, Bit 2=encrypted, Bit 3=case insensitive)
+Mode:                  0x000A  (Bit 0=signed, Bit 1=64-bit inodes, Bit 2=encrypted, Bit 3=case insensitive)
   Signed:              no
-  64-bit inodes:       no
+  64-bit inodes:       yes
   Encrypted:           no
   Case insensitive:    yes
 Block size:            65,536 bytes

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -23,7 +23,9 @@ from .pfs import (
     build_expected_fpt,
     build_pfs,
     build_tree_from_uroot,
+    choose_auto_fit_block_size,
     compose_pfs_mode_with_sign,
+    estimate_file_data_footprint,
     extract_pfs_image,
     human_readable_size,
     inspect_pfs_image,
@@ -62,8 +64,11 @@ def print_build_parameters(
     threshold_gain: int,
     cpu_count: int,
     zlib_level: int,
+    max_compressed_ratio: int | None,
+    min_compress_size: int,
     dry_run: bool,
     require_game_files: bool,
+    skip_executable_compression: bool = False,
 ) -> None:
     """Print build configuration at the start."""
     mode: int = compose_pfs_mode_with_sign(inode_bits, case_insensitive, signed)
@@ -91,12 +96,17 @@ def print_build_parameters(
     info(f"    New crypt:       {'yes' if new_crypt else 'no'}")
     info(f"    Case insensitive: {'yes' if mode & consts.PFS_MODE_CASE_INSENSITIVE else 'no'}")
     info(f"  Compression:       {'enabled' if compress else 'disabled'}")
+    if compress:
+        info(f"    Skip executables: {'yes' if skip_executable_compression else 'no'}")
     info(f"  Game-file checks:   {'required' if require_game_files else 'disabled'}")
     if compress:
         info(f"  Threshold gain:    {threshold_gain}%")
         cpu_label: str = "auto (max(1, cpu_count()))" if cpu_count == 0 else str(max(1, cpu_count))
         info(f"  CPU cores:         {cpu_label}")
         info(f"  Zlib level:        {zlib_level}")
+        if max_compressed_ratio is not None:
+            info(f"  Max PFSC ratio:    {max_compressed_ratio}%")
+        info(f"  Min compress size: {human_readable_size(min_compress_size)}")
     info(f"  Dry run:           {'yes' if dry_run else 'no'}")
     info("" + "=" * 70)
 
@@ -174,9 +184,9 @@ def print_summary(stats: BuildStats) -> None:
         info(f"    Uncompressed files:     {stats.uncompressed_files:,}")
         info(f"    Actual gain achieved:   {stats.actual_gain_pct:.2f}%")
         info(
-            "    Max theoretical gain:   "
+            "    All-PFSC gain:          "
             f"{stats.max_possible_gain_pct:.2f}%  "
-            f"({human_readable_size(stats.all_compressed_total_size)} if all files compressed)"
+            f"({human_readable_size(stats.all_compressed_total_size)} if every file used PFSC)"
         )
     else:
         info("\n  Compression:             disabled")
@@ -431,7 +441,9 @@ def cli_mkpfs_add_create_args(
         help="Minimum per-block gain percent to keep PFSC-compressed blocks (default: 20)",
     )
     parser.add_argument(
-        "--block-size", default="auto", help="PFS block size in bytes, or 'auto' (default: auto=65536)"
+        "--block-size",
+        default="auto",
+        help="PFS block size in bytes, 'auto' (65536), or 'auto-fit' to minimize estimated file-data padding",
     )
     parser.add_argument("--version", choices=["PS4", "PS5"], default="PS4", help="PFS profile version (default: PS4)")
     parser.add_argument(
@@ -449,6 +461,23 @@ def cli_mkpfs_add_create_args(
         help="Number of CPU cores for PFSC compression (0 = auto max(1, cpu_count()), non-zero = max(1, user value))",
     )
     parser.add_argument("--compression-level", type=int, default=7, help="Zlib compression level (0-9, default: 7)")
+    parser.add_argument(
+        "--max-compressed-ratio",
+        type=int,
+        default=None,
+        help="Maximum PFSC size as percent of the raw file size (0-100)",
+    )
+    parser.add_argument(
+        "--min-compress-size",
+        type=int,
+        default=0,
+        help="Store files smaller than this many bytes raw without trying PFSC compression (default: 0)",
+    )
+    parser.add_argument(
+        "--skip-executable-compression",
+        action="store_true",
+        help="Store eboot*.bin, *.prx, and *.sprx files raw even when PFSC compression is enabled",
+    )
     parser.add_argument("--signed", action="store_true", help="Build a signed PFS image using zero EKPFS/seed")
     parser.add_argument("--encrypted", action="store_true", help="Encrypt filesystem blocks with AES-XTS")
     parser.add_argument("--ekpfs-key", help="Optional 64-hex EKPFS key, defaults to all zeros when omitted")
@@ -502,13 +531,25 @@ def _run_pack_build(
     if args.threshold_gain < 0 or args.threshold_gain > 100:
         raise BuildError("--threshold-gain must be within 0..100")
 
-    if isinstance(args.block_size, str) and args.block_size.strip().lower() == "auto":
+    block_size_arg: str = str(args.block_size).strip().lower() if isinstance(args.block_size, str) else ""
+    if block_size_arg == "auto":
         block_size: int = 65536
+    elif block_size_arg in {"auto-fit", "auto_small_files", "auto-small-files"}:
+        block_size = choose_auto_fit_block_size(build_source_root)
+        file_sizes = [p.stat().st_size for p in build_source_root.rglob("*") if p.is_file()]
+        default_footprint: int = estimate_file_data_footprint(file_sizes=file_sizes, block_size=65536)
+        selected_footprint: int = estimate_file_data_footprint(file_sizes=file_sizes, block_size=block_size)
+        saved_bytes: int = max(0, default_footprint - selected_footprint)
+        info(
+            "Auto-fit block size selected: "
+            f"{block_size:,} bytes ({block_size // 1024} KiB), "
+            f"estimated file-data saving vs 64 KiB: {human_readable_size(saved_bytes)}"
+        )
     else:
         try:
             block_size = int(args.block_size)
         except (TypeError, ValueError) as exc:
-            raise BuildError("--block-size must be an integer value or 'auto'") from exc
+            raise BuildError("--block-size must be an integer value, 'auto', or 'auto-fit'") from exc
 
     if not is_power_of_two(block_size):
         raise BuildError("--block-size must be a power of two")
@@ -521,6 +562,11 @@ def _run_pack_build(
     if args.compression_level < 0 or args.compression_level > 9:
         raise BuildError("--compression-level must be within 0..9")
 
+    if args.max_compressed_ratio is not None and (args.max_compressed_ratio < 0 or args.max_compressed_ratio > 100):
+        raise BuildError("--max-compressed-ratio must be within 0..100")
+    if args.min_compress_size < 0:
+        raise BuildError("--min-compress-size must be non-negative")
+
     _title_id: str | None
     warnings: list[str]
     _title_id, warnings = validate_input(build_source_root, require_game_files=require_game_files)
@@ -528,6 +574,7 @@ def _run_pack_build(
         warning(w)
 
     compress: bool = not args.no_compress
+    min_file_gain: int = 100 - int(args.max_compressed_ratio) if args.max_compressed_ratio is not None else 0
     case_insensitive: bool = args.case_insensitive or not args.case_sensitive
     pfs_version: int = consts.PFS_VERSION_PS5 if args.version == "PS5" else consts.PFS_VERSION_PS4
     encrypted: bool = bool(getattr(args, "encrypted", False))
@@ -550,8 +597,11 @@ def _run_pack_build(
         args.threshold_gain,
         args.cpu_count,
         args.compression_level,
+        args.max_compressed_ratio,
+        args.min_compress_size,
         args.dry_run,
         require_game_files,
+        bool(getattr(args, "skip_executable_compression", False)),
     )
 
     if not args.dry_run:
@@ -577,6 +627,9 @@ def _run_pack_build(
         encrypted=encrypted,
         new_crypt=new_crypt,
         ekpfs=ekpfs_key,
+        skip_executable_compression=bool(getattr(args, "skip_executable_compression", False)),
+        min_file_gain=min_file_gain,
+        min_compress_size=args.min_compress_size,
     )
 
     stats.input_path = display_source_path

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import tempfile
 import time
 from collections.abc import Iterator
@@ -68,7 +69,7 @@ def print_build_parameters(
     min_compress_size: int,
     dry_run: bool,
     require_game_files: bool,
-    skip_executable_compression: bool = False,
+    skip_executable_compression: bool = True,
 ) -> None:
     """Print build configuration at the start."""
     mode: int = compose_pfs_mode_with_sign(inode_bits, case_insensitive, signed)
@@ -208,6 +209,64 @@ def print_summary(stats: BuildStats) -> None:
         info(f"  Throughput:              {human_readable_size(int(throughput))}/s")
 
     info("" * 70 + "\n")
+
+
+def resolve_disk_usage_probe_path(*, output_path: Path) -> Path:
+    """Resolve an existing path suitable for destination disk usage checks.
+
+    Args:
+        output_path: Requested output image path, possibly inside a directory
+            tree that does not exist yet.
+
+    Returns:
+        Existing directory path to probe with ``shutil.disk_usage``.
+    """
+    probe_path: Path = output_path.parent
+    root_path: Path = (probe_path.anchor and Path(probe_path.anchor)) or Path("/")
+    while not probe_path.exists() and probe_path != root_path:
+        probe_path = probe_path.parent
+    return probe_path if probe_path.exists() else root_path
+
+
+def calculate_source_raw_size_bytes(*, source_root: Path) -> int:
+    """Calculate total raw byte size for all files inside a source tree.
+
+    Args:
+        source_root: Directory used as pack source.
+
+    Returns:
+        Sum of raw ``st_size`` values for all files in the source tree.
+    """
+    total_raw_size_bytes: int = 0
+    candidate_path: Path
+    for candidate_path in source_root.rglob("*"):
+        if candidate_path.is_file():
+            total_raw_size_bytes += candidate_path.stat().st_size
+    return total_raw_size_bytes
+
+
+def get_destination_space_error_message(*, source_root: Path, output_path: Path) -> str | None:
+    """Build an insufficient-destination-space error for pack preflight.
+
+    Args:
+        source_root: Source directory whose raw file bytes must fit.
+        output_path: Requested output image destination.
+
+    Returns:
+        Error text when free destination space is insufficient, otherwise
+        ``None``.
+    """
+    required_raw_size_bytes: int = calculate_source_raw_size_bytes(source_root=source_root)
+    probe_path: Path = resolve_disk_usage_probe_path(output_path=output_path)
+    free_space_bytes: int = shutil.disk_usage(path=probe_path).free
+    if free_space_bytes >= required_raw_size_bytes:
+        return None
+    required_size_gb: float = required_raw_size_bytes / float(1024**3)
+    return (
+        "ERROR: The destination file is on a disk that does not have enough space "
+        f"({required_size_gb:.1f} GB) to perform the operation.\n"
+        "Operation cancelled."
+    )
 
 
 def prompt_overwrite(output_path: Path) -> bool:
@@ -437,8 +496,8 @@ def cli_mkpfs_add_create_args(
     parser.add_argument(
         "--threshold-gain",
         type=int,
-        default=20,
-        help="Minimum per-block gain percent to keep PFSC-compressed blocks (default: 20)",
+        default=0,
+        help="Minimum per-block gain percent to keep PFSC-compressed blocks (default: 0)",
     )
     parser.add_argument(
         "--block-size",
@@ -447,7 +506,7 @@ def cli_mkpfs_add_create_args(
     )
     parser.add_argument("--version", choices=["PS4", "PS5"], default="PS4", help="PFS profile version (default: PS4)")
     parser.add_argument(
-        "--inode-bits", type=int, choices=[32, 64], default=32, help="Inode width mode bit (32 or 64, default: 32)"
+        "--inode-bits", type=int, choices=[32, 64], default=64, help="Inode width mode bit (32 or 64, default: 64)"
     )
 
     case_group = parser.add_mutually_exclusive_group()
@@ -460,7 +519,7 @@ def cli_mkpfs_add_create_args(
         default=0,
         help="Number of CPU cores for PFSC compression (0 = auto max(1, cpu_count()), non-zero = max(1, user value))",
     )
-    parser.add_argument("--compression-level", type=int, default=7, help="Zlib compression level (0-9, default: 7)")
+    parser.add_argument("--compression-level", type=int, default=9, help="Zlib compression level (0-9, default: 9)")
     parser.add_argument(
         "--max-compressed-ratio",
         type=int,
@@ -476,6 +535,7 @@ def cli_mkpfs_add_create_args(
     parser.add_argument(
         "--skip-executable-compression",
         action="store_true",
+        default=True,
         help="Store eboot*.bin, *.prx, and *.sprx files raw even when PFSC compression is enabled",
     )
     parser.add_argument("--signed", action="store_true", help="Build a signed PFS image using zero EKPFS/seed")
@@ -603,6 +663,15 @@ def _run_pack_build(
         require_game_files,
         bool(getattr(args, "skip_executable_compression", False)),
     )
+
+    if not args.dry_run:
+        destination_space_error: str | None = get_destination_space_error_message(
+            source_root=build_source_root,
+            output_path=output_path,
+        )
+        if destination_space_error is not None:
+            error(destination_space_error)
+            return 1
 
     if not args.dry_run:
         cleanup_pack_temp_artifacts(output_path=output_path)

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -734,7 +734,7 @@ def store_file_node_raw(file_node: FileNode) -> None:
     file_node.stored_size = file_node.raw_size
     file_node.compressed = False
     file_node.gain_pct = 0.0
-    file_node.hypothetical_compressed_size = 0
+file_node.hypothetical_compressed_size = file_node.raw_size
 
 
 @dataclass

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -32,6 +32,7 @@ from .utils import _read_exact, ceil_div, human_readable_size, read_param_json
 
 PFSC_PROGRESS_REPORT_BYTES: int = consts.PFSC_LOGICAL_BLOCK_SIZE * 16
 PFSC_SINGLE_FILE_PARALLEL_MIN_SIZE: int = 256 * 1024 * 1024
+AUTO_FIT_BLOCK_SIZE_CANDIDATES: tuple[int, ...] = (0x1000, 0x2000, 0x4000, 0x8000, 0x10000)
 
 
 class SupportsIntQueue(Protocol):
@@ -42,6 +43,26 @@ class SupportsIntQueue(Protocol):
 
     def get_nowait(self) -> int:
         """Return the next queued byte delta without blocking."""
+
+
+def estimate_file_data_footprint(*, file_sizes: list[int], block_size: int) -> int:
+    """Estimate data-block footprint for file payloads at a given PFS block size."""
+    return sum((ceil_div(size, block_size) * block_size) if size > 0 else block_size for size in file_sizes)
+
+
+def choose_auto_fit_block_size(source_root: Path) -> int:
+    """Choose a PFS block size that minimizes estimated file-data footprint."""
+    file_sizes: list[int] = [p.stat().st_size for p in source_root.rglob("*") if p.is_file()]
+    if not file_sizes:
+        return consts.PFSC_LOGICAL_BLOCK_SIZE
+
+    return min(
+        AUTO_FIT_BLOCK_SIZE_CANDIDATES,
+        key=lambda candidate: (
+            estimate_file_data_footprint(file_sizes=file_sizes, block_size=candidate),
+            -candidate,
+        ),
+    )
 
 
 def validate_d32_ranges(inodes: list[Inode], final_ndblock: int) -> None:
@@ -696,6 +717,26 @@ class FileNode:
     inode: Inode | None = None
 
 
+def should_skip_executable_compression(file_name: str) -> bool:
+    """Return True for executable payloads that should stay raw when requested."""
+    lower_name: str = file_name.lower()
+    return (
+        (lower_name.startswith("eboot") and lower_name.endswith(".bin"))
+        or lower_name.endswith(".prx")
+        or lower_name.endswith(".sprx")
+    )
+
+
+def store_file_node_raw(file_node: FileNode) -> None:
+    """Mark a file node to be stored directly from the source file."""
+    file_node.stored_source_path = file_node.abs_path
+    file_node.stored_source_is_temp = False
+    file_node.stored_size = file_node.raw_size
+    file_node.compressed = False
+    file_node.gain_pct = 0.0
+    file_node.hypothetical_compressed_size = 0
+
+
 @dataclass
 class DirNode:
     rel_dir: str
@@ -987,6 +1028,7 @@ def _analyze_pfsc_file_storage(
     *,
     abs_path: Path,
     threshold_gain: int,
+    min_file_gain: int,
     zlib_level: int,
     logical_block_size: int,
     block_worker_count: int = 1,
@@ -997,6 +1039,7 @@ def _analyze_pfsc_file_storage(
     Args:
         abs_path: Source file path.
         threshold_gain: Minimum per-block gain percent to keep compressed bytes.
+        min_file_gain: Minimum whole-file gain percent required to store PFSC.
         zlib_level: zlib compression level.
         logical_block_size: PFSC logical block size.
         block_worker_count: Number of worker processes to use for block-level
@@ -1007,6 +1050,8 @@ def _analyze_pfsc_file_storage(
         Tuple ``(stored_size, is_compressed, gain_pct, hypothetical_all_compressed_size)``.
     """
     raw_size: int = abs_path.stat().st_size
+    if not (0 <= min_file_gain <= 100):
+        raise ValueError(f"min_file_gain must be between 0 and 100 inclusive, got {min_file_gain}")
     if raw_size == 0:
         return 0, False, 0.0, 0
 
@@ -1060,6 +1105,8 @@ def _analyze_pfsc_file_storage(
     if compressed_blocks == 0 or encoded_payload_size >= raw_size:
         return raw_size, False, 0.0, hypothetical_all_compressed_size
     effective_gain_pct: float = ((raw_size - encoded_payload_size) / raw_size) * 100.0
+    if effective_gain_pct < min_file_gain:
+        return raw_size, False, effective_gain_pct, hypothetical_all_compressed_size
     return encoded_payload_size, True, effective_gain_pct, hypothetical_all_compressed_size
 
 
@@ -1068,6 +1115,7 @@ def _encode_pfsc_file_to_spool(
     abs_path: Path,
     spool_path: Path,
     threshold_gain: int,
+    min_file_gain: int,
     zlib_level: int,
     logical_block_size: int,
     block_worker_count: int = 1,
@@ -1079,6 +1127,7 @@ def _encode_pfsc_file_to_spool(
         abs_path: Source file path.
         spool_path: Output spool file path for compressed PFSC payload.
         threshold_gain: Minimum per-block gain percent to keep compressed bytes.
+        min_file_gain: Minimum whole-file gain percent required to store PFSC.
         zlib_level: zlib compression level.
         logical_block_size: PFSC logical block size.
         block_worker_count: Number of worker processes to use for block-level
@@ -1089,6 +1138,8 @@ def _encode_pfsc_file_to_spool(
         Tuple ``(stored_size, is_compressed, gain_pct, hypothetical_all_compressed_size)``.
     """
     raw_size: int = abs_path.stat().st_size
+    if not (0 <= min_file_gain <= 100):
+        raise ValueError(f"min_file_gain must be between 0 and 100 inclusive, got {min_file_gain}")
     if raw_size == 0:
         return 0, False, 0.0, 0
 
@@ -1144,6 +1195,10 @@ def _encode_pfsc_file_to_spool(
         if compressed_blocks == 0 or encoded_payload_size >= raw_size:
             return raw_size, False, 0.0, hypothetical_all_compressed_size
 
+        effective_gain_pct: float = ((raw_size - encoded_payload_size) / raw_size) * 100.0
+        if effective_gain_pct < min_file_gain:
+            return raw_size, False, effective_gain_pct, hypothetical_all_compressed_size
+
         header: PFSCHeader = PFSCHeader(
             magic=consts.PFSC_MAGIC,
             unk4=consts.PFSC_UNK4,
@@ -1172,7 +1227,6 @@ def _encode_pfsc_file_to_spool(
         spool_file.write(header_area)
         spool_file.truncate(encoded_payload_size)
 
-    effective_gain_pct: float = ((raw_size - encoded_payload_size) / raw_size) * 100.0
     return encoded_payload_size, True, effective_gain_pct, hypothetical_all_compressed_size
 
 
@@ -1302,6 +1356,8 @@ def _compress_files_in_process(
     *,
     file_nodes_sorted: list[FileNode],
     threshold_gain: int,
+    min_file_gain: int,
+    min_compress_size: int,
     zlib_level: int,
     compression_cpu_count: int,
     dry_run: bool,
@@ -1313,6 +1369,8 @@ def _compress_files_in_process(
     Args:
         file_nodes_sorted: Ordered file nodes to process.
         threshold_gain: Minimum per-block gain threshold.
+        min_file_gain: Minimum whole-file gain percent required to store PFSC.
+        min_compress_size: Minimum raw file size required before trying PFSC.
         zlib_level: zlib compression level.
         compression_cpu_count: CPU budget available to block-level compression for
             a single file.
@@ -1354,13 +1412,8 @@ def _compress_files_in_process(
                 bytes_processed=displayed_progress_units if total_bytes_to_process > 0 else 0,
             )
 
-        if file_node.raw_size == 0:
-            file_node.stored_source_path = file_node.abs_path
-            file_node.stored_source_is_temp = False
-            file_node.stored_size = 0
-            file_node.compressed = False
-            file_node.gain_pct = 0.0
-            file_node.hypothetical_compressed_size = 0
+        if file_node.raw_size == 0 or file_node.raw_size < min_compress_size:
+            store_file_node_raw(file_node)
         else:
             block_worker_count: int = resolve_block_compression_worker_count(
                 requested_cpu_count=compression_cpu_count,
@@ -1374,6 +1427,7 @@ def _compress_files_in_process(
                 stored_size, is_compressed, gain_pct, hypothetical_compressed_size = _analyze_pfsc_file_storage(
                     abs_path=file_node.abs_path,
                     threshold_gain=threshold_gain,
+                    min_file_gain=min_file_gain,
                     zlib_level=zlib_level,
                     logical_block_size=consts.PFSC_LOGICAL_BLOCK_SIZE,
                     block_worker_count=block_worker_count,
@@ -1395,6 +1449,7 @@ def _compress_files_in_process(
                     abs_path=file_node.abs_path,
                     spool_path=spool_path,
                     threshold_gain=threshold_gain,
+                    min_file_gain=min_file_gain,
                     zlib_level=zlib_level,
                     logical_block_size=consts.PFSC_LOGICAL_BLOCK_SIZE,
                     block_worker_count=block_worker_count,
@@ -1691,6 +1746,8 @@ def compute_file_storage(
     file_node: FileNode,
     compress: bool,
     threshold_gain: int,
+    min_file_gain: int = 0,
+    min_compress_size: int = 0,
     block_size: int = consts.PFSC_LOGICAL_BLOCK_SIZE,
     zlib_level: int = zlib.Z_BEST_COMPRESSION,
 ) -> None:
@@ -1703,6 +1760,8 @@ def compute_file_storage(
         file_node: FileNode describing the file to process.
         compress: Whether compression is enabled.
         threshold_gain: Minimum percent gain required to keep compressed data.
+        min_file_gain: Minimum whole-file gain percent required to store PFSC.
+        min_compress_size: Minimum raw file size required before trying PFSC.
         block_size: PFSC logical block size used for compression planning.
         zlib_level: Compression level passed to zlib.compress.
 
@@ -1715,7 +1774,7 @@ def compute_file_storage(
         raise ValueError(f"threshold_gain must be between 0 and 100 inclusive, got {threshold_gain}")
 
     raw_size: int = file_node.abs_path.stat().st_size
-    if not compress or raw_size == 0:
+    if not compress or raw_size == 0 or raw_size < min_compress_size:
         file_node.stored_source_path = file_node.abs_path
         file_node.stored_source_is_temp = False
         file_node.stored_size = raw_size
@@ -1731,6 +1790,7 @@ def compute_file_storage(
     stored_size, is_compressed, gain_pct, hypothetical_size = _analyze_pfsc_file_storage(
         abs_path=file_node.abs_path,
         threshold_gain=threshold_gain,
+        min_file_gain=min_file_gain,
         zlib_level=zlib_level,
         logical_block_size=block_size,
         block_worker_count=1,
@@ -1744,7 +1804,7 @@ def compute_file_storage(
 
 
 def _compute_file_storage_worker(
-    args: tuple[Path, int, bool, int, int, bool, SupportsIntQueue | None],
+    args: tuple[Path, int, int, int, bool, int, int, bool, SupportsIntQueue | None],
 ) -> tuple[Path, Path, bool, int, bool, float, int]:
     """Worker function for parallel compression.
 
@@ -1753,7 +1813,7 @@ def _compute_file_storage_worker(
     of mutating a FileNode.
 
     Args:
-        args: Tuple containing ``(abs_path, threshold_gain, compress, block_size,
+        args: Tuple containing ``(abs_path, threshold_gain, min_file_gain, min_compress_size, compress, block_size,
             zlib_level, dry_run, progress_queue)``.
 
     Returns:
@@ -1762,15 +1822,27 @@ def _compute_file_storage_worker(
     """
     abs_path: Path
     threshold_gain: int
+    min_file_gain: int
+    min_compress_size: int
     compress: bool
     _block_size: int
     zlib_level: int
     dry_run: bool
     progress_queue: SupportsIntQueue | None
-    (abs_path, threshold_gain, compress, _block_size, zlib_level, dry_run, progress_queue) = args
+    (
+        abs_path,
+        threshold_gain,
+        min_file_gain,
+        min_compress_size,
+        compress,
+        _block_size,
+        zlib_level,
+        dry_run,
+        progress_queue,
+    ) = args
 
     raw_size: int = abs_path.stat().st_size
-    if not compress or raw_size == 0:
+    if not compress or raw_size == 0 or raw_size < min_compress_size:
         return abs_path, abs_path, False, raw_size, False, 0.0, 0
 
     batched_progress_bytes: int = 0
@@ -1791,6 +1863,7 @@ def _compute_file_storage_worker(
         stored_size, is_compressed, gain_pct, hypothetical_compressed_size = _analyze_pfsc_file_storage(
             abs_path=abs_path,
             threshold_gain=threshold_gain,
+            min_file_gain=min_file_gain,
             zlib_level=zlib_level,
             logical_block_size=consts.PFSC_LOGICAL_BLOCK_SIZE,
             block_worker_count=1,
@@ -1804,6 +1877,7 @@ def _compute_file_storage_worker(
             abs_path=abs_path,
             spool_path=spool_path,
             threshold_gain=threshold_gain,
+            min_file_gain=min_file_gain,
             zlib_level=zlib_level,
             logical_block_size=consts.PFSC_LOGICAL_BLOCK_SIZE,
             block_worker_count=1,
@@ -2134,12 +2208,19 @@ def build_pfs(
     encrypted: bool = False,
     new_crypt: bool = False,
     ekpfs: bytes | None = None,
+    skip_executable_compression: bool = False,
+    min_file_gain: int = 0,
+    min_compress_size: int = 0,
 ) -> BuildStats:
     start: float = time.time()
     progress: Progress = Progress(enabled=True)
     signed_inode_bits: int = 64 if signed and inode_bits == 64 else 32
     resolved_ekpfs: bytes = resolve_ekpfs_key(ekpfs=ekpfs)
     seed: bytes = consts.ZERO_PFS_SEED if (signed or encrypted) else b"\x00" * len(consts.ZERO_PFS_SEED)
+    if not (0 <= min_file_gain <= 100):
+        raise BuildError("min_file_gain must be within 0..100")
+    if min_compress_size < 0:
+        raise BuildError("min_compress_size must be non-negative")
 
     dirs: dict[str, DirNode]
     files: dict[str, FileNode]
@@ -2149,22 +2230,41 @@ def build_pfs(
     file_nodes_sorted: list[FileNode] = sorted(files.values(), key=lambda f: f.rel_path.lower())
     temporary_payload_paths: list[Path] = []
 
-    if compress and len(file_nodes_sorted) > 0:
+    compression_file_nodes: list[FileNode] = file_nodes_sorted
+    if compress and skip_executable_compression:
+        compression_file_nodes = []
+        for f in file_nodes_sorted:
+            if should_skip_executable_compression(f.name):
+                store_file_node_raw(f)
+            else:
+                compression_file_nodes.append(f)
+    if compress and min_compress_size > 0:
+        eligible_file_nodes: list[FileNode] = []
+        for f in compression_file_nodes:
+            if f.raw_size < min_compress_size:
+                store_file_node_raw(f)
+            else:
+                eligible_file_nodes.append(f)
+        compression_file_nodes = eligible_file_nodes
+
+    if compress and len(compression_file_nodes) > 0:
         # Calculate total bytes for compression progress
-        total_bytes_to_process: int = sum(f.raw_size for f in file_nodes_sorted)
+        total_bytes_to_process: int = sum(f.raw_size for f in compression_file_nodes)
         compression_cpu_count: int = resolve_compression_worker_count(requested_cpu_count=cpu_count)
         worker_count: int = compression_cpu_count
-        file_nodes_by_path: dict[Path, FileNode] = {f.abs_path: f for f in file_nodes_sorted}
+        file_nodes_by_path: dict[Path, FileNode] = {f.abs_path: f for f in compression_file_nodes}
         progress.status(
-            f"\nCompressing {len(file_nodes_sorted)} files ({human_readable_size(total_bytes_to_process)}) "
+            f"\nCompressing {len(compression_file_nodes)} files ({human_readable_size(total_bytes_to_process)}) "
             f"using {worker_count} CPU core{'s' if worker_count != 1 else ''}..."
         )
-        if worker_count == 1 or len(file_nodes_sorted) == 1:
+        if worker_count == 1 or len(compression_file_nodes) == 1:
             # Single-worker or single-file path uses in-process flow so a large file
             # can leverage block-level multiprocessing inside one file.
             _compress_files_in_process(
-                file_nodes_sorted=file_nodes_sorted,
+                file_nodes_sorted=compression_file_nodes,
                 threshold_gain=threshold_gain,
+                min_file_gain=min_file_gain,
+                min_compress_size=min_compress_size,
                 zlib_level=zlib_level,
                 compression_cpu_count=compression_cpu_count,
                 dry_run=dry_run,
@@ -2174,24 +2274,26 @@ def build_pfs(
         else:
             # Use multiprocessing for parallel compression.
             progress_total_units: int = (
-                total_bytes_to_process if total_bytes_to_process > 0 else len(file_nodes_sorted)
+                total_bytes_to_process if total_bytes_to_process > 0 else len(compression_file_nodes)
             )
             progress.step("compress", 0, progress_total_units, bytes_processed=0)
             total_bytes_processed: int = 0
             displayed_progress_units: int = 0
             with mp.Manager() as manager:
                 progress_queue: SupportsIntQueue = manager.Queue()
-                worker_args: list[tuple[Path, int, bool, int, int, bool, SupportsIntQueue | None]] = [
+                worker_args: list[tuple[Path, int, int, int, bool, int, int, bool, SupportsIntQueue | None]] = [
                     (
                         f.abs_path,
                         threshold_gain,
+                        min_file_gain,
+                        min_compress_size,
                         True,
                         consts.PFSC_LOGICAL_BLOCK_SIZE,
                         zlib_level,
                         dry_run,
                         progress_queue,
                     )
-                    for f in file_nodes_sorted
+                    for f in compression_file_nodes
                 ]
                 with mp.Pool(processes=worker_count) as pool:
                     results = pool.imap_unordered(_compute_file_storage_worker, worker_args, chunksize=1)
@@ -2255,7 +2357,7 @@ def build_pfs(
             temporary_payload_paths.extend(
                 [
                     file_node.stored_source_path
-                    for file_node in file_nodes_sorted
+                    for file_node in compression_file_nodes
                     if file_node.stored_source_is_temp and file_node.stored_source_path is not None
                 ]
             )
@@ -4238,6 +4340,9 @@ def pfs_build(
     verbose: bool,
     encrypted: bool = False,
     ekpfs: bytes | None = None,
+    skip_executable_compression: bool = False,
+    min_file_gain: int = 0,
+    min_compress_size: int = 0,
 ) -> BuildStats:
     """Stable thin wrapper around :func:`build_pfs`.
 
@@ -4260,6 +4365,9 @@ def pfs_build(
         verbose=verbose,
         encrypted=encrypted,
         ekpfs=ekpfs,
+        skip_executable_compression=skip_executable_compression,
+        min_file_gain=min_file_gain,
+        min_compress_size=min_compress_size,
     )
 
 

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -734,7 +734,8 @@ def store_file_node_raw(file_node: FileNode) -> None:
     file_node.stored_size = file_node.raw_size
     file_node.compressed = False
     file_node.gain_pct = 0.0
-file_node.hypothetical_compressed_size = file_node.raw_size
+
+    file_node.hypothetical_compressed_size = file_node.raw_size
 
 
 @dataclass

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -2520,12 +2520,11 @@ def build_pfs(
             ino.number = idx
             remap[old] = idx
 
+        # Inode objects are already renumbered in-place above. Only dirent links
+        # still carry old inode numbers and need remapping.
         for d in dir_nodes_sorted:
-            d.inode.number = remap[d.inode.number]
             for ent in d.dirents:
                 ent.inode_number = remap[ent.inode_number]
-        for f in file_nodes_sorted:
-            f.inode.number = remap[f.inode.number]
 
         inode_by_path = {}
         for d in dir_nodes_sorted:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mkpfs"
-version = "0.0.2"
+version = "0.0.3"
 description = "Create and Manage Unsigned PFS (Playstation File System) image files with file compression and checksum support."
 readme = "README.md"
 authors = [{ name = "PSBrew", email = "contact@psbrew.com" }]

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -67,6 +67,8 @@ class CliTestCase(unittest.TestCase):
             case_insensitive=True,
             cpu_count=0,
             compression_level=7,
+            min_compress_size=0,
+            max_compressed_ratio=None,
             signed=False,
             encrypted=False,
             ekpfs_key=None,
@@ -93,6 +95,8 @@ class CliTestCase(unittest.TestCase):
             case_insensitive=True,
             cpu_count=0,
             compression_level=7,
+            min_compress_size=0,
+            max_compressed_ratio=None,
             signed=False,
             encrypted=False,
             ekpfs_key=None,
@@ -176,6 +180,42 @@ class TestCliArgumentHelpers(CliTestCase):
             action for action in folder_parser._actions if getattr(action, "dest", "") == "compression_level"
         )
         self.assertEqual(compression_action.default, 7)
+
+    def test_pack_parser_exposes_executable_compression_skip_flag(self) -> None:
+        """The pack parser should expose an opt-in executable compression skip."""
+        parser: argparse.ArgumentParser = cli.cli_mkpfs_main_parsers()
+        pack_parser: argparse.ArgumentParser = next(
+            action.choices["pack"] for action in parser._actions if isinstance(action, argparse._SubParsersAction)
+        )
+        pack_choices: dict[str, argparse.ArgumentParser] = next(
+            action.choices for action in pack_parser._actions if isinstance(action, argparse._SubParsersAction)
+        )
+        folder_parser: argparse.ArgumentParser = pack_choices["folder"]
+        skip_action: argparse.Action = next(
+            action for action in folder_parser._actions if getattr(action, "dest", "") == "skip_executable_compression"
+        )
+        self.assertFalse(skip_action.default)
+        self.assertIsNotNone(skip_action.help)
+        self.assertIn("eboot*.bin", skip_action.help or "")
+
+    def test_pack_parser_exposes_whole_file_compression_threshold(self) -> None:
+        """The pack parser should expose the whole-file compression threshold."""
+        parser: argparse.ArgumentParser = cli.cli_mkpfs_main_parsers()
+        pack_parser: argparse.ArgumentParser = next(
+            action.choices["pack"] for action in parser._actions if isinstance(action, argparse._SubParsersAction)
+        )
+        pack_choices: dict[str, argparse.ArgumentParser] = next(
+            action.choices for action in pack_parser._actions if isinstance(action, argparse._SubParsersAction)
+        )
+        folder_parser: argparse.ArgumentParser = pack_choices["folder"]
+        max_ratio_action: argparse.Action = next(
+            action for action in folder_parser._actions if getattr(action, "dest", "") == "max_compressed_ratio"
+        )
+        min_size_action: argparse.Action = next(
+            action for action in folder_parser._actions if getattr(action, "dest", "") == "min_compress_size"
+        )
+        self.assertIsNone(max_ratio_action.default)
+        self.assertEqual(min_size_action.default, 0)
 
     def test_pack_parser_cpu_count_help_mentions_auto_and_user_normalization(self) -> None:
         """The pack parser should document auto and explicit worker normalization rules."""
@@ -367,6 +407,8 @@ class TestCliOutputFormatting(CliTestCase):
                 threshold_gain=20,
                 cpu_count=0,
                 zlib_level=7,
+                max_compressed_ratio=None,
+                min_compress_size=0,
                 dry_run=True,
                 require_game_files=False,
             )
@@ -490,6 +532,35 @@ class TestCliCreateRun(CliTestCase):
         self.assertEqual(mocked_build.call_args.kwargs["output_path"].name, "custom-name.img")
         self.assertNotIn("adjusting output file extension", stdout_buffer.getvalue())
 
+    def test_create_run_auto_fit_block_size_selects_small_blocks_for_small_files(self) -> None:
+        """The auto-fit block-size mode should pick a smaller block size for small-file trees."""
+        tmp_path: Path = self.make_temp_path()
+        source_path: Path = self.make_valid_source(tmp_path)
+        data_path: Path = source_path / "data"
+        data_path.mkdir()
+        for idx in range(32):
+            (data_path / f"small_{idx:02d}.bin").write_bytes(b"x" * 100)
+        args: SimpleNamespace = self.make_create_args(
+            source_path=source_path,
+            image_path=tmp_path / "out",
+            dry_run=True,
+            verify=False,
+        )
+        args.block_size = "auto-fit"
+        stdout_buffer: StringIO = StringIO()
+
+        with patch.object(
+            cli, "build_pfs", return_value=self.make_build_stats(tmp_path)
+        ) as mocked_build, patch.object(
+            cli,
+            "prompt_overwrite",
+            return_value=True,
+        ), redirect_stdout(stdout_buffer):
+            self.assertEqual(cli.cli_mkpfs_create_run(args), 0)
+
+        self.assertEqual(mocked_build.call_args.kwargs["block_size"], 4096)
+        self.assertIn("Auto-fit block size selected", stdout_buffer.getvalue())
+
     def test_create_run_requires_game_files_when_flag_is_enabled(self) -> None:
         """Pack should fail fast when strict game-file validation is enabled and files are missing."""
         tmp_path: Path = self.make_temp_path()
@@ -562,6 +633,18 @@ class TestCliCreateRun(CliTestCase):
             bad_level: SimpleNamespace = SimpleNamespace(**bad_level_dict)
             with self.assertRaises(BuildError):
                 cli.cli_mkpfs_create_run(bad_level)
+
+            bad_max_ratio_dict: dict[str, object] = base_args.copy()
+            bad_max_ratio_dict["max_compressed_ratio"] = 101
+            bad_max_ratio: SimpleNamespace = SimpleNamespace(**bad_max_ratio_dict)
+            with self.assertRaises(BuildError):
+                cli.cli_mkpfs_create_run(bad_max_ratio)
+
+            bad_min_size_dict: dict[str, object] = base_args.copy()
+            bad_min_size_dict["min_compress_size"] = -1
+            bad_min_size: SimpleNamespace = SimpleNamespace(**bad_min_size_dict)
+            with self.assertRaises(BuildError):
+                cli.cli_mkpfs_create_run(bad_min_size)
 
             bad_key_dict: dict[str, object] = base_args.copy()
             bad_key_dict["encrypted"] = True

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
-from contextlib import ExitStack, redirect_stdout
+from contextlib import ExitStack, redirect_stderr, redirect_stdout
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
@@ -166,8 +166,8 @@ class TestCliArgumentHelpers(CliTestCase):
         )
         self.assertEqual(set(choices), {"pack", "verify", "inspect", "tree", "unpack"})
 
-    def test_pack_parser_uses_default_compression_level_of_seven(self) -> None:
-        """The pack parser should expose 7 as the default compression level."""
+    def test_pack_parser_uses_default_compression_level_of_nine(self) -> None:
+        """The pack parser should expose 9 as the default compression level."""
         parser: argparse.ArgumentParser = cli.cli_mkpfs_main_parsers()
         pack_parser: argparse.ArgumentParser = next(
             action.choices["pack"] for action in parser._actions if isinstance(action, argparse._SubParsersAction)
@@ -179,10 +179,40 @@ class TestCliArgumentHelpers(CliTestCase):
         compression_action = next(
             action for action in folder_parser._actions if getattr(action, "dest", "") == "compression_level"
         )
-        self.assertEqual(compression_action.default, 7)
+        self.assertEqual(compression_action.default, 9)
+
+    def test_pack_parser_uses_zero_as_default_threshold_gain(self) -> None:
+        """The pack parser should expose 0 as the default threshold gain."""
+        parser: argparse.ArgumentParser = cli.cli_mkpfs_main_parsers()
+        pack_parser: argparse.ArgumentParser = next(
+            action.choices["pack"] for action in parser._actions if isinstance(action, argparse._SubParsersAction)
+        )
+        pack_choices: dict[str, argparse.ArgumentParser] = next(
+            action.choices for action in pack_parser._actions if isinstance(action, argparse._SubParsersAction)
+        )
+        folder_parser: argparse.ArgumentParser = pack_choices["folder"]
+        threshold_action: argparse.Action = next(
+            action for action in folder_parser._actions if getattr(action, "dest", "") == "threshold_gain"
+        )
+        self.assertEqual(threshold_action.default, 0)
+
+    def test_pack_parser_uses_sixty_four_as_default_inode_bits(self) -> None:
+        """The pack parser should expose 64 as the default inode width."""
+        parser: argparse.ArgumentParser = cli.cli_mkpfs_main_parsers()
+        pack_parser: argparse.ArgumentParser = next(
+            action.choices["pack"] for action in parser._actions if isinstance(action, argparse._SubParsersAction)
+        )
+        pack_choices: dict[str, argparse.ArgumentParser] = next(
+            action.choices for action in pack_parser._actions if isinstance(action, argparse._SubParsersAction)
+        )
+        folder_parser: argparse.ArgumentParser = pack_choices["folder"]
+        inode_bits_action: argparse.Action = next(
+            action for action in folder_parser._actions if getattr(action, "dest", "") == "inode_bits"
+        )
+        self.assertEqual(inode_bits_action.default, 64)
 
     def test_pack_parser_exposes_executable_compression_skip_flag(self) -> None:
-        """The pack parser should expose an opt-in executable compression skip."""
+        """The pack parser should default to skipping executable compression."""
         parser: argparse.ArgumentParser = cli.cli_mkpfs_main_parsers()
         pack_parser: argparse.ArgumentParser = next(
             action.choices["pack"] for action in parser._actions if isinstance(action, argparse._SubParsersAction)
@@ -194,7 +224,7 @@ class TestCliArgumentHelpers(CliTestCase):
         skip_action: argparse.Action = next(
             action for action in folder_parser._actions if getattr(action, "dest", "") == "skip_executable_compression"
         )
-        self.assertFalse(skip_action.default)
+        self.assertTrue(skip_action.default)
         self.assertIsNotNone(skip_action.help)
         self.assertIn("eboot*.bin", skip_action.help or "")
 
@@ -679,6 +709,75 @@ class TestCliCreateRun(CliTestCase):
         ):
             self.assertEqual(cli.cli_mkpfs_create_run(args), 0)
         mocked_cleanup.assert_called_once()
+
+    def test_create_run_returns_error_when_destination_disk_is_too_small(self) -> None:
+        """Create run should fail early when destination free space is below raw source size."""
+        tmp_path: Path = self.make_temp_path()
+        source_path: Path = self.make_valid_source(tmp_path)
+        args: SimpleNamespace = self.make_create_args(
+            source_path=source_path,
+            image_path=tmp_path / "out.ffpfs",
+            dry_run=False,
+            verify=False,
+        )
+        stderr_buffer: StringIO = StringIO()
+        with patch.object(cli, "validate_input", return_value=("TITLE", [])), patch.object(
+            cli,
+            "cleanup_pack_temp_artifacts",
+            side_effect=AssertionError("cleanup should not run"),
+        ), patch.object(
+            cli,
+            "prompt_overwrite",
+            side_effect=AssertionError("prompt should not run"),
+        ), patch.object(
+            cli,
+            "build_pfs",
+            side_effect=AssertionError("build should not run"),
+        ), patch.object(
+            cli.shutil,
+            "disk_usage",
+            return_value=SimpleNamespace(total=10, used=9, free=1),
+        ), redirect_stderr(stderr_buffer):
+            self.assertEqual(cli.cli_mkpfs_create_run(args), 1)
+        self.assertIn(
+            "ERROR: The destination file is on a disk that does not have enough space", stderr_buffer.getvalue()
+        )
+        self.assertIn("Operation cancelled.", stderr_buffer.getvalue())
+
+    def test_pack_file_run_returns_error_when_destination_disk_is_too_small(self) -> None:
+        """Pack file should fail early when destination free space is below raw source size."""
+        tmp_path: Path = self.make_temp_path()
+        source_file: Path = tmp_path / "single.bin"
+        source_file.write_bytes(b"payload")
+        args: SimpleNamespace = self.make_pack_file_args(
+            source_path=source_file,
+            image_path=tmp_path / "out.ffpfsc",
+            dry_run=False,
+            verify=False,
+        )
+        stderr_buffer: StringIO = StringIO()
+        with patch.object(cli, "validate_input", return_value=(None, [])), patch.object(
+            cli,
+            "cleanup_pack_temp_artifacts",
+            side_effect=AssertionError("cleanup should not run"),
+        ), patch.object(
+            cli,
+            "prompt_overwrite",
+            side_effect=AssertionError("prompt should not run"),
+        ), patch.object(
+            cli,
+            "build_pfs",
+            side_effect=AssertionError("build should not run"),
+        ), patch.object(
+            cli.shutil,
+            "disk_usage",
+            return_value=SimpleNamespace(total=10, used=9, free=1),
+        ), redirect_stderr(stderr_buffer):
+            self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 1)
+        self.assertIn(
+            "ERROR: The destination file is on a disk that does not have enough space", stderr_buffer.getvalue()
+        )
+        self.assertIn("Operation cancelled.", stderr_buffer.getvalue())
 
     def test_create_run_runs_post_verify_and_returns_error_when_check_fails(self) -> None:
         """Create run should perform post-verify and return a failure code when verification reports errors."""

--- a/tests/mkpfs/test_pfs.py
+++ b/tests/mkpfs/test_pfs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import random
 import struct
 import subprocess
 import sys
@@ -405,6 +406,146 @@ class TestEncryptedImageRoundTrip(PfsTestCase):
             assert len(compressed_payload) == compressed_inode.size
             assert compressed_payload[:4] == b"PFSC"
 
+    def test_executable_compression_skip_keeps_eboot_prx_and_sprx_raw(self) -> None:
+        """Requested executable compression skips should leave eboot*.bin, *.prx, and *.sprx inodes raw."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = make_app_with_nested_dirs(tmp_path / "src")
+        eboot_path: Path = src / "eboot_patch.bin"
+        prx_path: Path = src / "modules" / "libsample.prx"
+        sprx_path: Path = src / "modules" / "libsample.sprx"
+        normal_path: Path = src / "data" / "large.bin"
+        prx_path.parent.mkdir(parents=True)
+        eboot_payload: bytes = b"E" * 200000
+        prx_payload: bytes = b"P" * 200000
+        sprx_payload: bytes = b"X" * 200000
+        normal_payload: bytes = b"N" * 200000
+        eboot_path.write_bytes(eboot_payload)
+        prx_path.write_bytes(prx_payload)
+        sprx_path.write_bytes(sprx_payload)
+        normal_path.write_bytes(normal_payload)
+        out: Path = tmp_path / "skip-executables.ffpfs"
+        build_pfs(
+            source_root=src,
+            output_path=out,
+            block_size=65536,
+            pfs_version=c.PFS_VERSION_PS4,
+            inode_bits=32,
+            case_insensitive=True,
+            signed=False,
+            compress=True,
+            threshold_gain=1,
+            cpu_count=1,
+            zlib_level=9,
+            dry_run=False,
+            verbose=False,
+            encrypted=False,
+            skip_executable_compression=True,
+        )
+
+        with out.open("rb") as fh:
+            header: pfs_mod.ParsedHeader = parse_image_header(fh)
+            inspection: pfs_mod.PFSImageInspection = inspect_pfs_image(image=out, source=src)
+            assert inspection.errors == []
+
+            eboot_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["eboot_patch.bin"]]
+            prx_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["modules/libsample.prx"]]
+            sprx_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["modules/libsample.sprx"]]
+            normal_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["data/large.bin"]]
+
+            assert not eboot_inode.is_compressed
+            assert not prx_inode.is_compressed
+            assert not sprx_inode.is_compressed
+            assert normal_inode.is_compressed
+            assert pfs_mod.read_image_inode_payload(fh, header, eboot_inode) == eboot_payload
+            assert pfs_mod.read_image_inode_payload(fh, header, prx_inode) == prx_payload
+            assert pfs_mod.read_image_inode_payload(fh, header, sprx_inode) == sprx_payload
+            assert pfs_mod.read_image_inode_payload(fh, header, normal_inode)[:4] == b"PFSC"
+
+    def test_min_file_gain_keeps_low_gain_files_raw(self) -> None:
+        """Whole-file gain thresholds should reject PFSC payloads below the requested gain."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = make_app_with_nested_dirs(tmp_path / "src")
+        rng: random.Random = random.Random(12345)
+        low_gain_payload: bytes = (b"\x00" * (c.PFSC_LOGICAL_BLOCK_SIZE * 4)) + bytes(
+            rng.randrange(0, 256) for _ in range(c.PFSC_LOGICAL_BLOCK_SIZE)
+        )
+        high_gain_payload: bytes = b"H" * (c.PFSC_LOGICAL_BLOCK_SIZE * 100)
+        low_gain_path: Path = src / "data" / "low_gain.bin"
+        high_gain_path: Path = src / "data" / "high_gain.bin"
+        low_gain_path.write_bytes(low_gain_payload)
+        high_gain_path.write_bytes(high_gain_payload)
+        out: Path = tmp_path / "whole-file-gain.ffpfs"
+
+        build_pfs(
+            source_root=src,
+            output_path=out,
+            block_size=65536,
+            pfs_version=c.PFS_VERSION_PS4,
+            inode_bits=32,
+            case_insensitive=True,
+            signed=False,
+            compress=True,
+            threshold_gain=1,
+            min_file_gain=95,
+            cpu_count=1,
+            zlib_level=9,
+            dry_run=False,
+            verbose=False,
+            encrypted=False,
+        )
+
+        with out.open("rb") as fh:
+            header: pfs_mod.ParsedHeader = parse_image_header(fh)
+            inspection: pfs_mod.PFSImageInspection = inspect_pfs_image(image=out, source=src)
+            assert inspection.errors == []
+            low_gain_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["data/low_gain.bin"]]
+            high_gain_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["data/high_gain.bin"]]
+            assert not low_gain_inode.is_compressed
+            assert high_gain_inode.is_compressed
+            assert pfs_mod.read_image_inode_payload(fh, header, low_gain_inode) == low_gain_payload
+            assert pfs_mod.read_image_inode_payload(fh, header, high_gain_inode)[:4] == b"PFSC"
+
+    def test_min_compress_size_skips_small_files_before_pfsc(self) -> None:
+        """Files below the requested compression size floor should be stored raw."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = make_app_with_nested_dirs(tmp_path / "src")
+        small_path: Path = src / "data" / "small_repeated.bin"
+        large_path: Path = src / "data" / "large_repeated.bin"
+        small_payload: bytes = b"S" * 4096
+        large_payload: bytes = b"L" * 200000
+        small_path.write_bytes(small_payload)
+        large_path.write_bytes(large_payload)
+        out: Path = tmp_path / "min-compress-size.ffpfs"
+
+        build_pfs(
+            source_root=src,
+            output_path=out,
+            block_size=65536,
+            pfs_version=c.PFS_VERSION_PS4,
+            inode_bits=32,
+            case_insensitive=True,
+            signed=False,
+            compress=True,
+            threshold_gain=1,
+            cpu_count=1,
+            zlib_level=9,
+            dry_run=False,
+            verbose=False,
+            encrypted=False,
+            min_compress_size=65536,
+        )
+
+        with out.open("rb") as fh:
+            header: pfs_mod.ParsedHeader = parse_image_header(fh)
+            inspection: pfs_mod.PFSImageInspection = inspect_pfs_image(image=out, source=src)
+            assert inspection.errors == []
+            small_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["data/small_repeated.bin"]]
+            large_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["data/large_repeated.bin"]]
+            assert not small_inode.is_compressed
+            assert large_inode.is_compressed
+            assert pfs_mod.read_image_inode_payload(fh, header, small_inode) == small_payload
+            assert pfs_mod.read_image_inode_payload(fh, header, large_inode)[:4] == b"PFSC"
+
     def test_pfsc_encode_decode_round_trip(self) -> None:
         """PFSC payload encoding and decoding should preserve logical bytes."""
         raw: bytes = (b"A" * 65536) + (b"B" * 65536) + (b"C" * 1234)
@@ -474,6 +615,8 @@ class TestEncryptedImageRoundTrip(PfsTestCase):
             (
                 file_path,
                 1,
+                0,
+                0,
                 True,
                 c.PFSC_LOGICAL_BLOCK_SIZE,
                 9,
@@ -535,6 +678,7 @@ class TestEncryptedImageRoundTrip(PfsTestCase):
             *,
             abs_path: Path,
             threshold_gain: int,
+            min_file_gain: int,
             zlib_level: int,
             logical_block_size: int,
             block_worker_count: int = 1,
@@ -546,6 +690,7 @@ class TestEncryptedImageRoundTrip(PfsTestCase):
             if progress_callback is not None:
                 progress_callback(raw_size)
             _ = threshold_gain
+            _ = min_file_gain
             _ = zlib_level
             _ = logical_block_size
             return raw_size, False, 0.0, 0
@@ -588,6 +733,7 @@ class TestEncryptedImageRoundTrip(PfsTestCase):
             abs_path=source_path,
             spool_path=sequential_spool,
             threshold_gain=1,
+            min_file_gain=0,
             zlib_level=7,
             logical_block_size=c.PFSC_LOGICAL_BLOCK_SIZE,
             block_worker_count=1,
@@ -596,6 +742,7 @@ class TestEncryptedImageRoundTrip(PfsTestCase):
             abs_path=source_path,
             spool_path=parallel_spool,
             threshold_gain=1,
+            min_file_gain=0,
             zlib_level=7,
             logical_block_size=c.PFSC_LOGICAL_BLOCK_SIZE,
             block_worker_count=2,
@@ -1860,3 +2007,13 @@ class TestSourceTreeScanning(PfsTestCase):
     def test_scan_source_tree_returns_expected_directory_and_file_maps(self) -> None:
         """Scanning a small source tree should return the expected files, directories, and count."""
         assert_scan_source_tree(self.make_temp_path())
+
+    def test_auto_fit_block_size_prefers_small_blocks_for_small_files(self) -> None:
+        """Auto-fit block-size selection should minimize estimated file-data footprint."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "src"
+        src.mkdir()
+        for idx in range(10):
+            (src / f"small_{idx}.bin").write_bytes(b"x" * 100)
+
+        assert pfs_mod.choose_auto_fit_block_size(src) == 4096

--- a/tests/mkpfs/test_pfs.py
+++ b/tests/mkpfs/test_pfs.py
@@ -546,6 +546,33 @@ class TestEncryptedImageRoundTrip(PfsTestCase):
             assert pfs_mod.read_image_inode_payload(fh, header, small_inode) == small_payload
             assert pfs_mod.read_image_inode_payload(fh, header, large_inode)[:4] == b"PFSC"
 
+    def test_build_pfs_handles_fpt_collision_inode_renumbering(self) -> None:
+        """Forced FPT collisions should not break inode renumbering during build."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = make_app_with_nested_dirs(tmp_path / "src")
+        out: Path = tmp_path / "collision-renumbering.ffpfs"
+
+        with patch.object(pfs_mod, "fpt_hash", return_value=0x12345678):
+            build_pfs(
+                source_root=src,
+                output_path=out,
+                block_size=65536,
+                pfs_version=c.PFS_VERSION_PS4,
+                inode_bits=32,
+                case_insensitive=True,
+                signed=False,
+                compress=True,
+                threshold_gain=1,
+                cpu_count=1,
+                zlib_level=9,
+                dry_run=False,
+                verbose=False,
+                encrypted=False,
+            )
+
+        assert out.is_file()
+        assert out.stat().st_size > 0
+
     def test_pfsc_encode_decode_round_trip(self) -> None:
         """PFSC payload encoding and decoding should preserve logical bytes."""
         raw: bytes = (b"A" * 65536) + (b"B" * 65536) + (b"C" * 1234)

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "mkpfs"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography", version = "47.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version <= '3.9'" },


### PR DESCRIPTION
Mkpfs 0.0.3

- Solves a bug related to inode remaps (Reported by Alex )
- Adds the features implemented by Drakmor to skip binaries when compressing folders (Implemented by Drakmor and reviewd by Renan)
- Changed some default values to solve issues related to small games not benefiting from compression (Requested by Alex and TataNano)
- Added a check to see if the destination disk has enought space left for the final file. (Requested by TataNano)
- Change inode to use 64 bits by default in order to accomodate large games (Reported by Drakmor)