### PR TITLE
Fix temp dir location for cross-drive hardlink failures on Windows

### DIFF
--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -780,6 +780,12 @@ def _stage_single_file_source_root(*, source_file: Path, temp_folder: Path | Non
     The staged file is created as a hard link when possible, with a symlink
     fallback when hard linking is unavailable in the current environment.
 
+    On Windows, hard links cannot cross drives (WinError 17) and symlinks
+    require the "Create Symbolic Links" privilege (WinError 1314), which
+    most users lack. If ``source_file`` and ``temp_folder`` reside on
+    different devices, the staging directory is created next to the source
+    file instead so the hard link succeeds.
+
     Args:
         source_file: Existing source file that should appear at the temporary
             root path.
@@ -793,8 +799,19 @@ def _stage_single_file_source_root(*, source_file: Path, temp_folder: Path | Non
     Raises:
         BuildError: If no link strategy can stage the file.
     """
-    temp_root: Path = resolve_temp_root(temp_folder=temp_folder)
-    with tempfile.TemporaryDirectory(dir=str(temp_root)) as staging_dir_name:
+    # Determine the best location for the staging directory.
+    # On Windows, hardlinks cannot cross drives (WinError 17) and symlinks
+    # require the "Create Symbolic Links" privilege (WinError 1314), which
+    # most users lack. Prefer the user's temp_folder, but fall back to
+    # the source file's parent directory when they are on different drives.
+    _staging_base: Path = temp_folder if temp_folder is not None else source_file.parent
+    try:
+        if source_file.stat().st_dev != _staging_base.stat().st_dev:
+            _staging_base = source_file.parent
+    except OSError:
+        pass  # stat failed, keep original base
+
+    with tempfile.TemporaryDirectory(dir=str(_staging_base)) as staging_dir_name:
         staging_root: Path = Path(staging_dir_name)
         staging_file: Path = staging_root / source_file.name
         try:


### PR DESCRIPTION
On Windows, hardlinks cannot cross drives (WinError 17) and symlinks require the 'Create Symbolic Links' privilege (WinError 1314), which most users lack. Previously, when the source file and temp folder were on different drives, both linking strategies would fail.

Detect cross-drive scenarios by comparing st_dev of source and temp folder. When they differ, create the staging directory next to the source file so the hardlink succeeds. When on the same drive, respect the user's temp_folder preference.