### PR TITLE
Spool-free streaming `pack file` (`--no-spool`) with flat-memory verify/unpack/tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,9 @@ docs/_build/
 # PyBuilder
 .pybuilder/
 target/
+
+# test files
+*.ffpfsc
+*.ffpfs
+*.exfat
+*.ffpkg

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from . import consts
 from .logging import error, info, warning
+from .pbar import Progress
 from .pfs import (
     BuildError,
     BuildStats,
@@ -371,6 +372,8 @@ def run_image_check(
     warnings: list[str] = []
     tree: dict[int, list[ParsedDirent]] = {}
     uroot_inode = -1
+    # Show verify/compare progress only for interactive report runs.
+    progress: Progress = Progress(enabled=emit_report)
 
     if not image.exists() or not image.is_file():
         return [f"image path does not exist or is not a file: {image}"], [], tree, uroot_inode
@@ -414,6 +417,7 @@ def run_image_check(
                 errors,
                 ekpfs=ekpfs,
                 new_crypt=new_crypt,
+                progress=progress,
             )
 
             if expected_crc32 is not None and data_crc32 != expected_crc32:
@@ -434,7 +438,15 @@ def run_image_check(
 
             if source is not None:
                 validate_source_match(
-                    fh, header, inodes, file_inodes, source, errors, ekpfs=ekpfs, new_crypt=new_crypt
+                    fh,
+                    header,
+                    inodes,
+                    file_inodes,
+                    source,
+                    errors,
+                    ekpfs=ekpfs,
+                    new_crypt=new_crypt,
+                    progress=progress,
                 )
 
             compressed_count = sum(1 for i in file_inodes.values() if inodes[i].is_compressed)

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -24,6 +24,7 @@ from .pfs import (
     PFSImageInspection,
     build_expected_fpt,
     build_pfs,
+    build_pfs_stream_single_file,
     build_tree_from_uroot,
     choose_auto_fit_block_size,
     compose_pfs_mode_with_sign,
@@ -861,6 +862,103 @@ def cli_mkpfs_create_run(args: argparse.Namespace) -> int:
     )
 
 
+def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int:
+    """Pack a single file with the spool-free streaming builder.
+
+    Args:
+        args: Parsed CLI arguments for the file pack workflow.
+        source_file: Resolved source file path.
+
+    Returns:
+        Process exit code for the streaming file packing workflow.
+
+    Raises:
+        BuildError: If CLI parameters are invalid.
+    """
+    output_path: Path
+    output_changed: bool
+    output_path, output_changed = normalize_output_path(
+        args.image_file,
+        ".ffpfsc",
+        adjust=bool(getattr(args, "adjust_output_file_extension", True)),
+    )
+    output_path = output_path.expanduser().resolve()
+    if output_changed:
+        info("Single file streaming mode enabled, adjusting output file extension to .ffpfsc")
+
+    # Validate the subset of pack parameters the streaming builder honors.
+    block_size_arg: str = str(args.block_size).strip().lower() if isinstance(args.block_size, str) else ""
+    if block_size_arg in {"auto", ""}:
+        block_size: int = 65536
+    else:
+        try:
+            block_size = int(args.block_size)
+        except (TypeError, ValueError) as exc:
+            raise BuildError("--block-size must be an integer value or 'auto' for --no-spool") from exc
+    if not is_power_of_two(block_size) or block_size < 0x1000 or block_size > 0x200000:
+        raise BuildError("--block-size must be a power of two between 4096 and 2097152")
+    if args.threshold_gain < 0 or args.threshold_gain > 100:
+        raise BuildError("--threshold-gain must be within 0..100")
+    if args.cpu_count < 0:
+        raise BuildError("--cpu-count must be non-negative")
+    if args.compression_level < 0 or args.compression_level > 9:
+        raise BuildError("--compression-level must be within 0..9")
+    if args.max_compressed_ratio is not None and (args.max_compressed_ratio < 0 or args.max_compressed_ratio > 100):
+        raise BuildError("--max-compressed-ratio must be within 0..100")
+    if args.min_compress_size < 0:
+        raise BuildError("--min-compress-size must be non-negative")
+
+    compress: bool = not args.no_compress
+    min_file_gain: int = 100 - int(args.max_compressed_ratio) if args.max_compressed_ratio is not None else 0
+    case_insensitive: bool = args.case_insensitive or not args.case_sensitive
+    pfs_version: int = consts.PFS_VERSION_PS5 if args.version == "PS5" else consts.PFS_VERSION_PS4
+    encrypted: bool = bool(getattr(args, "encrypted", False))
+    new_crypt: bool = bool(getattr(args, "new_crypt", False))
+    ekpfs_key: bytes = parse_ekpfs_key_hex(getattr(args, "ekpfs_key", None))
+    if getattr(args, "ekpfs_key", None) and not encrypted:
+        raise BuildError("--ekpfs-key requires --encrypted")
+
+    if not prompt_overwrite(output_path):
+        info("Operation cancelled.")
+        return 0
+
+    stats: BuildStats = build_pfs_stream_single_file(
+        source_file=source_file,
+        output_path=output_path,
+        block_size=block_size,
+        pfs_version=pfs_version,
+        case_insensitive=case_insensitive,
+        zlib_level=args.compression_level,
+        threshold_gain=args.threshold_gain,
+        min_file_gain=min_file_gain,
+        min_compress_size=args.min_compress_size,
+        cpu_count=args.cpu_count,
+        compress=compress,
+        encrypted=encrypted,
+        new_crypt=new_crypt,
+        ekpfs=ekpfs_key,
+        verbose=args.verbose,
+    )
+    stats.input_path = source_file
+    print_summary(stats)
+    if not args.verify:
+        return 0
+
+    info("Running post-create check...")
+    errors, warnings, _tree, _uroot = run_image_check(
+        output_path,
+        source_file,
+        print_tree=False,
+        ekpfs=ekpfs_key,
+        new_crypt=new_crypt,
+    )
+    for w in warnings:
+        warning(w)
+    for e in errors:
+        error(e)
+    return 1 if errors else 0
+
+
 def cli_mkpfs_pack_file_run(args: argparse.Namespace) -> int:
     """Pack a single file into a PFS image.
 
@@ -874,6 +972,12 @@ def cli_mkpfs_pack_file_run(args: argparse.Namespace) -> int:
     temp_folder: Path = _resolve_pack_temp_folder(args)
     if not source_file.exists() or not source_file.is_file():
         raise BuildError(f"--source-file must be an existing file: {source_file}")
+
+    # Spool-free streaming path (file path only, unsigned images).
+    if getattr(args, "no_spool", False):
+        if args.signed:
+            raise BuildError("--no-spool does not support --signed images")
+        return _run_stream_pack_file(args=args, source_file=source_file)
 
     with _stage_single_file_source_root(source_file=source_file, temp_folder=temp_folder) as staging_root:
         return _run_pack_build(
@@ -1154,6 +1258,12 @@ def cli_mkpfs_main_parsers() -> argparse.ArgumentParser:
         source_arg_name="source_file",
         source_help="Single source file to pack",
         include_require_game_files=False,
+    )
+    file_parser.add_argument(
+        "--no-spool",
+        action="store_true",
+        help="Stream-compress the source file directly into the image with no temp spool "
+        "(file path only; unsigned images, encryption supported)",
     )
     file_parser.set_defaults(
         inode_bits=32,

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -11,6 +11,7 @@ import tempfile
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager, suppress
+from dataclasses import dataclass
 from pathlib import Path
 
 from . import consts
@@ -612,6 +613,167 @@ def _resolve_pack_temp_folder(args: argparse.Namespace) -> Path:
     return resolve_temp_root(temp_folder=temp_folder)
 
 
+@dataclass(frozen=True)
+class PackBuildConfig:
+    """Validated, derived pack options shared by folder and single-file flows.
+
+    Attributes:
+        block_size: Resolved filesystem block size in bytes.
+        compress: Whether PFSC compression is enabled.
+        threshold_gain: Minimum per-block gain percent to keep PFSC blocks.
+        min_file_gain: Minimum whole-file gain percent required to store PFSC.
+        min_compress_size: Minimum raw size eligible for PFSC.
+        case_insensitive: Whether the case-insensitive mode bit is set.
+        pfs_version: PFS profile version number.
+        encrypted: Whether filesystem blocks are encrypted.
+        new_crypt: Whether the alternate EKPFS derivation is used.
+        ekpfs_key: Resolved EKPFS key material.
+        zlib_level: Zlib compression level.
+        cpu_count: Requested CPU worker count.
+        skip_executable_compression: Whether executable-like files stay raw.
+        inode_bits: Inode width in bits.
+    """
+
+    block_size: int
+    compress: bool
+    threshold_gain: int
+    min_file_gain: int
+    max_compressed_ratio: int | None
+    min_compress_size: int
+    case_insensitive: bool
+    pfs_version: int
+    encrypted: bool
+    new_crypt: bool
+    ekpfs_key: bytes
+    zlib_level: int
+    cpu_count: int
+    skip_executable_compression: bool
+    inode_bits: int
+
+
+def _resolve_pack_build_config(args: argparse.Namespace, *, block_size: int) -> PackBuildConfig:
+    """Validate shared pack CLI options and derive the common build configuration.
+
+    Args:
+        args: Parsed pack CLI arguments.
+        block_size: Resolved block size (already chosen via auto/auto-fit/explicit).
+
+    Returns:
+        Validated configuration shared by the folder and single-file pack flows.
+
+    Raises:
+        BuildError: If any shared pack parameter is invalid.
+    """
+    if not is_power_of_two(block_size):
+        raise BuildError("--block-size must be a power of two")
+    if block_size < 0x1000 or block_size > 0x200000:
+        raise BuildError("--block-size must be between 4096 and 2097152")
+    if args.threshold_gain < 0 or args.threshold_gain > 100:
+        raise BuildError("--threshold-gain must be within 0..100")
+    if args.cpu_count < 0:
+        raise BuildError("--cpu-count must be non-negative")
+    if args.compression_level < 0 or args.compression_level > 9:
+        raise BuildError("--compression-level must be within 0..9")
+    if args.max_compressed_ratio is not None and (args.max_compressed_ratio < 0 or args.max_compressed_ratio > 100):
+        raise BuildError("--max-compressed-ratio must be within 0..100")
+    if args.min_compress_size < 0:
+        raise BuildError("--min-compress-size must be non-negative")
+
+    encrypted: bool = bool(getattr(args, "encrypted", False))
+    ekpfs_key: bytes = parse_ekpfs_key_hex(getattr(args, "ekpfs_key", None))
+    if getattr(args, "ekpfs_key", None) and not encrypted:
+        raise BuildError("--ekpfs-key requires --encrypted")
+
+    return PackBuildConfig(
+        block_size=block_size,
+        compress=not args.no_compress,
+        threshold_gain=args.threshold_gain,
+        min_file_gain=100 - int(args.max_compressed_ratio) if args.max_compressed_ratio is not None else 0,
+        max_compressed_ratio=args.max_compressed_ratio,
+        min_compress_size=args.min_compress_size,
+        case_insensitive=args.case_insensitive or not args.case_sensitive,
+        pfs_version=consts.PFS_VERSION_PS5 if args.version == "PS5" else consts.PFS_VERSION_PS4,
+        encrypted=encrypted,
+        new_crypt=bool(getattr(args, "new_crypt", False)),
+        ekpfs_key=ekpfs_key,
+        zlib_level=args.compression_level,
+        cpu_count=args.cpu_count,
+        skip_executable_compression=bool(getattr(args, "skip_executable_compression", False)),
+        inode_bits=args.inode_bits,
+    )
+
+
+def _print_pack_parameters(
+    *,
+    config: PackBuildConfig,
+    display_source_path: Path,
+    output_path: Path,
+    temp_folder: Path,
+    signed: bool,
+    require_game_files: bool,
+    dry_run: bool,
+) -> None:
+    """Print the build parameters banner from a resolved pack configuration.
+
+    Args:
+        config: Resolved pack build configuration.
+        display_source_path: Original user-facing source path.
+        output_path: Final output image path.
+        temp_folder: Temporary folder used for pack artifacts.
+        signed: Whether signed mode is enabled.
+        require_game_files: Whether strict game-file validation is enabled.
+        dry_run: Whether the build is a dry run.
+    """
+    print_build_parameters(
+        display_source_path,
+        output_path,
+        temp_folder,
+        config.block_size,
+        config.pfs_version,
+        config.inode_bits,
+        config.case_insensitive,
+        signed,
+        config.encrypted,
+        config.new_crypt,
+        config.compress,
+        config.threshold_gain,
+        config.cpu_count,
+        config.zlib_level,
+        config.max_compressed_ratio,
+        config.min_compress_size,
+        dry_run,
+        require_game_files,
+        config.skip_executable_compression,
+    )
+
+
+def _run_post_pack_verify(*, output_path: Path, source: Path, ekpfs_key: bytes, new_crypt: bool) -> int:
+    """Run the post-pack image check and report warnings and errors.
+
+    Args:
+        output_path: Written image to verify.
+        source: Source directory compared against the image.
+        ekpfs_key: EKPFS key material for encrypted images.
+        new_crypt: Whether to use the alternate newCrypt derivation.
+
+    Returns:
+        ``1`` when the check reports errors, otherwise ``0``.
+    """
+    info("Running post-create check...")
+    errors, warnings, _tree, _uroot = run_image_check(
+        output_path,
+        source,
+        print_tree=False,
+        ekpfs=ekpfs_key,
+        new_crypt=new_crypt,
+    )
+    for w in warnings:
+        warning(w)
+    for e in errors:
+        error(e)
+    return 1 if errors else 0
+
+
 def _run_pack_build(
     *,
     args: argparse.Namespace,
@@ -650,9 +812,7 @@ def _run_pack_build(
     if output_changed:
         info(output_adjustment_message)
 
-    if args.threshold_gain < 0 or args.threshold_gain > 100:
-        raise BuildError("--threshold-gain must be within 0..100")
-
+    # Resolve block size (folder path additionally supports auto-fit over the tree).
     block_size_arg: str = str(args.block_size).strip().lower() if isinstance(args.block_size, str) else ""
     if block_size_arg == "auto":
         block_size: int = 65536
@@ -673,21 +833,7 @@ def _run_pack_build(
         except (TypeError, ValueError) as exc:
             raise BuildError("--block-size must be an integer value, 'auto', or 'auto-fit'") from exc
 
-    if not is_power_of_two(block_size):
-        raise BuildError("--block-size must be a power of two")
-    if block_size < 0x1000 or block_size > 0x200000:
-        raise BuildError("--block-size must be between 4096 and 2097152")
-
-    if args.cpu_count < 0:
-        raise BuildError("--cpu-count must be non-negative")
-
-    if args.compression_level < 0 or args.compression_level > 9:
-        raise BuildError("--compression-level must be within 0..9")
-
-    if args.max_compressed_ratio is not None and (args.max_compressed_ratio < 0 or args.max_compressed_ratio > 100):
-        raise BuildError("--max-compressed-ratio must be within 0..100")
-    if args.min_compress_size < 0:
-        raise BuildError("--min-compress-size must be non-negative")
+    config: PackBuildConfig = _resolve_pack_build_config(args, block_size=block_size)
 
     _title_id: str | None
     warnings: list[str]
@@ -695,36 +841,14 @@ def _run_pack_build(
     for w in warnings:
         warning(w)
 
-    compress: bool = not args.no_compress
-    min_file_gain: int = 100 - int(args.max_compressed_ratio) if args.max_compressed_ratio is not None else 0
-    case_insensitive: bool = args.case_insensitive or not args.case_sensitive
-    pfs_version: int = consts.PFS_VERSION_PS5 if args.version == "PS5" else consts.PFS_VERSION_PS4
-    encrypted: bool = bool(getattr(args, "encrypted", False))
-    new_crypt: bool = bool(getattr(args, "new_crypt", False))
-    ekpfs_key: bytes = parse_ekpfs_key_hex(getattr(args, "ekpfs_key", None))
-    if getattr(args, "ekpfs_key", None) and not encrypted:
-        raise BuildError("--ekpfs-key requires --encrypted")
-
-    print_build_parameters(
-        display_source_path,
-        output_path,
-        temp_folder,
-        block_size,
-        pfs_version,
-        args.inode_bits,
-        case_insensitive,
-        args.signed,
-        encrypted,
-        new_crypt,
-        compress,
-        args.threshold_gain,
-        args.cpu_count,
-        args.compression_level,
-        args.max_compressed_ratio,
-        args.min_compress_size,
-        args.dry_run,
-        require_game_files,
-        bool(getattr(args, "skip_executable_compression", False)),
+    _print_pack_parameters(
+        config=config,
+        display_source_path=display_source_path,
+        output_path=output_path,
+        temp_folder=temp_folder,
+        signed=args.signed,
+        require_game_files=require_game_files,
+        dry_run=args.dry_run,
     )
 
     if not args.dry_run:
@@ -745,23 +869,23 @@ def _run_pack_build(
     stats: BuildStats = build_pfs(
         source_root=build_source_root,
         output_path=output_path,
-        block_size=block_size,
-        pfs_version=pfs_version,
-        inode_bits=args.inode_bits,
-        case_insensitive=case_insensitive,
+        block_size=config.block_size,
+        pfs_version=config.pfs_version,
+        inode_bits=config.inode_bits,
+        case_insensitive=config.case_insensitive,
         signed=args.signed,
-        compress=compress,
-        threshold_gain=args.threshold_gain,
-        cpu_count=args.cpu_count,
-        zlib_level=args.compression_level,
+        compress=config.compress,
+        threshold_gain=config.threshold_gain,
+        cpu_count=config.cpu_count,
+        zlib_level=config.zlib_level,
         dry_run=args.dry_run,
         verbose=args.verbose,
-        encrypted=encrypted,
-        new_crypt=new_crypt,
-        ekpfs=ekpfs_key,
-        skip_executable_compression=bool(getattr(args, "skip_executable_compression", False)),
-        min_file_gain=min_file_gain,
-        min_compress_size=args.min_compress_size,
+        encrypted=config.encrypted,
+        new_crypt=config.new_crypt,
+        ekpfs=config.ekpfs_key,
+        skip_executable_compression=config.skip_executable_compression,
+        min_file_gain=config.min_file_gain,
+        min_compress_size=config.min_compress_size,
         temp_folder=temp_folder,
     )
 
@@ -770,20 +894,12 @@ def _run_pack_build(
     if args.dry_run or not args.verify:
         return 0
 
-    info("Running post-create check...")
-    errors, warnings, _tree, _uroot = run_image_check(
-        output_path,
-        compare_source_root,
-        print_tree=False,
-        ekpfs=ekpfs_key,
-        new_crypt=new_crypt,
+    return _run_post_pack_verify(
+        output_path=output_path,
+        source=compare_source_root,
+        ekpfs_key=config.ekpfs_key,
+        new_crypt=config.new_crypt,
     )
-
-    for w in warnings:
-        warning(w)
-    for e in errors:
-        error(e)
-    return 1 if errors else 0
 
 
 @contextmanager
@@ -898,7 +1014,7 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
     if output_changed:
         info("Single file streaming mode enabled, adjusting output file extension to .ffpfsc")
 
-    # Validate the subset of pack parameters the streaming builder honors.
+    # Resolve block size (single-file path: auto or explicit, no auto-fit).
     block_size_arg: str = str(args.block_size).strip().lower() if isinstance(args.block_size, str) else ""
     if block_size_arg in {"auto", ""}:
         block_size: int = 65536
@@ -907,50 +1023,17 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
             block_size = int(args.block_size)
         except (TypeError, ValueError) as exc:
             raise BuildError("--block-size must be an integer value or 'auto' for --no-spool") from exc
-    if not is_power_of_two(block_size) or block_size < 0x1000 or block_size > 0x200000:
-        raise BuildError("--block-size must be a power of two between 4096 and 2097152")
-    if args.threshold_gain < 0 or args.threshold_gain > 100:
-        raise BuildError("--threshold-gain must be within 0..100")
-    if args.cpu_count < 0:
-        raise BuildError("--cpu-count must be non-negative")
-    if args.compression_level < 0 or args.compression_level > 9:
-        raise BuildError("--compression-level must be within 0..9")
-    if args.max_compressed_ratio is not None and (args.max_compressed_ratio < 0 or args.max_compressed_ratio > 100):
-        raise BuildError("--max-compressed-ratio must be within 0..100")
-    if args.min_compress_size < 0:
-        raise BuildError("--min-compress-size must be non-negative")
 
-    compress: bool = not args.no_compress
-    min_file_gain: int = 100 - int(args.max_compressed_ratio) if args.max_compressed_ratio is not None else 0
-    case_insensitive: bool = args.case_insensitive or not args.case_sensitive
-    pfs_version: int = consts.PFS_VERSION_PS5 if args.version == "PS5" else consts.PFS_VERSION_PS4
-    encrypted: bool = bool(getattr(args, "encrypted", False))
-    new_crypt: bool = bool(getattr(args, "new_crypt", False))
-    ekpfs_key: bytes = parse_ekpfs_key_hex(getattr(args, "ekpfs_key", None))
-    if getattr(args, "ekpfs_key", None) and not encrypted:
-        raise BuildError("--ekpfs-key requires --encrypted")
-
+    config: PackBuildConfig = _resolve_pack_build_config(args, block_size=block_size)
     temp_folder: Path = _resolve_pack_temp_folder(args)
-    print_build_parameters(
-        source_file,
-        output_path,
-        temp_folder,
-        block_size,
-        pfs_version,
-        32,
-        case_insensitive,
-        False,
-        encrypted,
-        new_crypt,
-        compress,
-        args.threshold_gain,
-        args.cpu_count,
-        args.compression_level,
-        args.max_compressed_ratio,
-        args.min_compress_size,
-        False,
-        False,
-        bool(getattr(args, "skip_executable_compression", False)),
+    _print_pack_parameters(
+        config=config,
+        display_source_path=source_file,
+        output_path=output_path,
+        temp_folder=temp_folder,
+        signed=False,
+        require_game_files=False,
+        dry_run=False,
     )
 
     if not prompt_overwrite(output_path):
@@ -960,18 +1043,18 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
     stats: BuildStats = build_pfs_stream_single_file(
         source_file=source_file,
         output_path=output_path,
-        block_size=block_size,
-        pfs_version=pfs_version,
-        case_insensitive=case_insensitive,
-        zlib_level=args.compression_level,
-        threshold_gain=args.threshold_gain,
-        min_file_gain=min_file_gain,
-        min_compress_size=args.min_compress_size,
-        cpu_count=args.cpu_count,
-        compress=compress,
-        encrypted=encrypted,
-        new_crypt=new_crypt,
-        ekpfs=ekpfs_key,
+        block_size=config.block_size,
+        pfs_version=config.pfs_version,
+        case_insensitive=config.case_insensitive,
+        zlib_level=config.zlib_level,
+        threshold_gain=config.threshold_gain,
+        min_file_gain=config.min_file_gain,
+        min_compress_size=config.min_compress_size,
+        cpu_count=config.cpu_count,
+        compress=config.compress,
+        encrypted=config.encrypted,
+        new_crypt=config.new_crypt,
+        ekpfs=config.ekpfs_key,
         verbose=args.verbose,
     )
     stats.input_path = source_file
@@ -979,22 +1062,15 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
     if not args.verify:
         return 0
 
-    info("Running post-create check...")
     # Stage the single file into a temp directory (hardlink, no data copy) so the
     # check compares against a directory tree, mirroring the verify command.
     with _stage_single_file_source_root(source_file=source_file, temp_folder=temp_folder) as staging_root:
-        errors, warnings, _tree, _uroot = run_image_check(
-            output_path,
-            staging_root,
-            print_tree=False,
-            ekpfs=ekpfs_key,
-            new_crypt=new_crypt,
+        return _run_post_pack_verify(
+            output_path=output_path,
+            source=staging_root,
+            ekpfs_key=config.ekpfs_key,
+            new_crypt=config.new_crypt,
         )
-    for w in warnings:
-        warning(w)
-    for e in errors:
-        error(e)
-    return 1 if errors else 0
 
 
 def cli_mkpfs_pack_file_run(args: argparse.Namespace) -> int:

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -1016,6 +1016,10 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
 
     # Resolve block size (single-file path: auto or explicit, no auto-fit).
     block_size_arg: str = str(args.block_size).strip().lower() if isinstance(args.block_size, str) else ""
+    if block_size_arg in {"auto-fit", "auto_small_files", "auto-small-files"}:
+        raise BuildError(
+            "--block-size auto-fit is not supported for single-file packing; use 'auto' or an explicit size"
+        )
     if block_size_arg in {"auto", ""}:
         block_size: int = 65536
     else:
@@ -1033,10 +1037,10 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
         temp_folder=temp_folder,
         signed=False,
         require_game_files=False,
-        dry_run=False,
+        dry_run=args.dry_run,
     )
 
-    if not prompt_overwrite(output_path):
+    if not args.dry_run and not prompt_overwrite(output_path):
         info("Operation cancelled.")
         return 0
 
@@ -1056,10 +1060,12 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
         new_crypt=config.new_crypt,
         ekpfs=config.ekpfs_key,
         verbose=args.verbose,
+        skip_executable_compression=config.skip_executable_compression,
+        dry_run=args.dry_run,
     )
     stats.input_path = source_file
     print_summary(stats)
-    if not args.verify:
+    if args.dry_run or not args.verify:
         return 0
 
     # Stage the single file into a temp directory (hardlink, no data copy) so the
@@ -1091,6 +1097,8 @@ def cli_mkpfs_pack_file_run(args: argparse.Namespace) -> int:
     if getattr(args, "no_spool", False):
         if args.signed:
             raise BuildError("--no-spool does not support --signed images")
+        if getattr(args, "inode_bits", 32) != 32:
+            raise BuildError("--no-spool only supports 32-bit inodes (use --inode-bits 32)")
         return _run_stream_pack_file(args=args, source_file=source_file)
 
     with _stage_single_file_source_root(source_file=source_file, temp_folder=temp_folder) as staging_root:

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -918,6 +918,29 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
     if getattr(args, "ekpfs_key", None) and not encrypted:
         raise BuildError("--ekpfs-key requires --encrypted")
 
+    temp_folder: Path = _resolve_pack_temp_folder(args)
+    print_build_parameters(
+        source_file,
+        output_path,
+        temp_folder,
+        block_size,
+        pfs_version,
+        32,
+        case_insensitive,
+        False,
+        encrypted,
+        new_crypt,
+        compress,
+        args.threshold_gain,
+        args.cpu_count,
+        args.compression_level,
+        args.max_compressed_ratio,
+        args.min_compress_size,
+        False,
+        False,
+        bool(getattr(args, "skip_executable_compression", False)),
+    )
+
     if not prompt_overwrite(output_path):
         info("Operation cancelled.")
         return 0
@@ -947,7 +970,6 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
     info("Running post-create check...")
     # Stage the single file into a temp directory (hardlink, no data copy) so the
     # check compares against a directory tree, mirroring the verify command.
-    temp_folder: Path = _resolve_pack_temp_folder(args)
     with _stage_single_file_source_root(source_file=source_file, temp_folder=temp_folder) as staging_root:
         errors, warnings, _tree, _uroot = run_image_check(
             output_path,

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -933,14 +933,14 @@ def _stage_single_file_source_root(*, source_file: Path, temp_folder: Path | Non
     # require the "Create Symbolic Links" privilege (WinError 1314), which
     # most users lack. Prefer the user's temp_folder, but fall back to
     # the source file's parent directory when they are on different drives.
-    _staging_base: Path = temp_folder if temp_folder is not None else source_file.parent
+    staging_base: Path = temp_folder if temp_folder is not None else source_file.parent
     try:
-        if source_file.stat().st_dev != _staging_base.stat().st_dev:
-            _staging_base = source_file.parent
+        if source_file.stat().st_dev != staging_base.stat().st_dev:
+            staging_base = source_file.parent
     except OSError:
         pass  # stat failed, keep original base
 
-    with tempfile.TemporaryDirectory(dir=str(_staging_base)) as staging_dir_name:
+    with tempfile.TemporaryDirectory(dir=str(staging_base)) as staging_dir_name:
         staging_root: Path = Path(staging_dir_name)
         staging_file: Path = staging_root / source_file.name
         try:

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -945,13 +945,17 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
         return 0
 
     info("Running post-create check...")
-    errors, warnings, _tree, _uroot = run_image_check(
-        output_path,
-        source_file,
-        print_tree=False,
-        ekpfs=ekpfs_key,
-        new_crypt=new_crypt,
-    )
+    # Stage the single file into a temp directory (hardlink, no data copy) so the
+    # check compares against a directory tree, mirroring the verify command.
+    temp_folder: Path = _resolve_pack_temp_folder(args)
+    with _stage_single_file_source_root(source_file=source_file, temp_folder=temp_folder) as staging_root:
+        errors, warnings, _tree, _uroot = run_image_check(
+            output_path,
+            staging_root,
+            print_tree=False,
+            ekpfs=ekpfs_key,
+            new_crypt=new_crypt,
+        )
     for w in warnings:
         warning(w)
     for e in errors:

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -368,6 +368,7 @@ def run_image_check(
     emit_report: bool = True,
     ekpfs: bytes | None = None,
     new_crypt: bool = False,
+    verify_payloads: bool = True,
 ) -> tuple[list[str], list[str], dict[int, list[ParsedDirent]], int]:
     errors: list[str] = []
     warnings: list[str] = []
@@ -408,25 +409,36 @@ def run_image_check(
             case_insensitive = bool(header.mode & consts.PFS_MODE_CASE_INSENSITIVE)
             expected_fpt = build_expected_fpt(file_inodes, dir_inodes, case_insensitive)
             validate_fpt_maps(fpt_map, collision_map, expected_fpt, errors)
-            validate_ps5_checklist(fh, header, inodes, file_inodes, warnings, errors, ekpfs=ekpfs, new_crypt=new_crypt)
-
-            checked_files, data_crc32, manifest_sha256 = verify_file_payload_hashes(
-                fh,
-                header,
-                inodes,
-                file_inodes,
-                errors,
-                ekpfs=ekpfs,
-                new_crypt=new_crypt,
-                progress=progress,
-            )
-
-            if expected_crc32 is not None and data_crc32 != expected_crc32:
-                errors.append(f"CRC32 mismatch: actual 0x{data_crc32:08X}, expected 0x{expected_crc32:08X}")
-            if expected_manifest_sha256 is not None and manifest_sha256.lower() != expected_manifest_sha256.lower():
-                errors.append(
-                    f"Manifest SHA256 mismatch: actual {manifest_sha256}, expected {expected_manifest_sha256.lower()}"
+            # Payload-content passes (decode every file). Skipped for structure-only
+            # callers such as the tree listing, which need only the directory layout.
+            checked_files: int = 0
+            data_crc32: int = 0
+            manifest_sha256: str = ""
+            if verify_payloads:
+                validate_ps5_checklist(
+                    fh, header, inodes, file_inodes, warnings, errors, ekpfs=ekpfs, new_crypt=new_crypt
                 )
+                checked_files, data_crc32, manifest_sha256 = verify_file_payload_hashes(
+                    fh,
+                    header,
+                    inodes,
+                    file_inodes,
+                    errors,
+                    ekpfs=ekpfs,
+                    new_crypt=new_crypt,
+                    progress=progress,
+                )
+
+                if expected_crc32 is not None and data_crc32 != expected_crc32:
+                    errors.append(f"CRC32 mismatch: actual 0x{data_crc32:08X}, expected 0x{expected_crc32:08X}")
+                if (
+                    expected_manifest_sha256 is not None
+                    and manifest_sha256.lower() != expected_manifest_sha256.lower()
+                ):
+                    errors.append(
+                        f"Manifest SHA256 mismatch: actual {manifest_sha256}, "
+                        f"expected {expected_manifest_sha256.lower()}"
+                    )
 
             reachable = set(file_inodes.values()) | set(dir_inodes.values()) | set(special_inodes)
             orphan_inodes = sorted(i.number for i in inodes if i.number not in reachable)
@@ -1216,6 +1228,7 @@ def cli_mkpfs_ls_run(args: argparse.Namespace) -> int:
         emit_report=False,
         ekpfs=parse_ekpfs_key_hex(getattr(args, "ekpfs_key", None)),
         new_crypt=bool(getattr(args, "new_crypt", False)),
+        verify_payloads=False,
     )
     if errors:
         for e in errors:

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -4355,10 +4355,21 @@ def verify_file_payload_hashes(
     errors: list[str],
     ekpfs: bytes | None = None,
     new_crypt: bool = False,
+    progress: Progress | None = None,
 ) -> tuple[int, int, str]:
     manifest = hashlib.sha256()
     cumulative_crc = 0
     checked = 0
+
+    # Report progress against the total logical bytes to hash, throttled by volume.
+    total_bytes: int = sum(max(0, inodes[n].logical_size) for n in file_inodes.values())
+    progress_total: int = max(total_bytes, 1)
+    processed: int = 0
+    last_reported: int = 0
+    update_interval: int = 8 * 1024 * 1024
+    if progress is not None:
+        progress.step("verify", 0, progress_total, bytes_processed=0)
+
     for rel in sorted(file_inodes.keys()):
         inode_num = file_inodes[rel]
         inode = inodes[inode_num]
@@ -4370,6 +4381,10 @@ def verify_file_payload_hashes(
                 file_hash.update(chunk)
                 cumulative_crc = zlib.crc32(chunk, cumulative_crc) & 0xFFFFFFFF
                 file_len += len(chunk)
+                processed += len(chunk)
+                if progress is not None and processed - last_reported >= update_interval:
+                    last_reported = processed
+                    progress.step("verify", min(processed, total_bytes), progress_total, bytes_processed=processed)
         except (ValueError, OSError) as exc:
             errors.append(f"failed to read file payload '{rel}' (inode {inode_num}): {exc}")
             continue
@@ -4381,6 +4396,9 @@ def verify_file_payload_hashes(
         manifest.update(b"\0")
         manifest.update(file_hash.digest())
         checked += 1
+
+    if progress is not None:
+        progress.step("verify", progress_total, progress_total, bytes_processed=total_bytes)
 
     return checked, cumulative_crc, manifest.hexdigest()
 
@@ -4538,6 +4556,7 @@ def validate_source_match(
     errors: list[str],
     ekpfs: bytes | None = None,
     new_crypt: bool = False,
+    progress: Progress | None = None,
 ) -> None:
     if not source.exists() or not source.is_dir():
         errors.append(f"source path does not exist or is not a directory: {source}")
@@ -4552,13 +4571,27 @@ def validate_source_match(
     for rel in sorted(image_rel - source_rel):
         errors.append(f"extra in image: {rel}")
 
-    for rel in sorted(source_rel & image_rel):
+    common = sorted(source_rel & image_rel)
+    # Report progress against the total logical bytes to compare, throttled by volume.
+    total_bytes: int = sum(max(0, inodes[file_inodes[rel]].logical_size) for rel in common)
+    progress_total: int = max(total_bytes, 1)
+    processed: int = 0
+    last_reported: int = 0
+    update_interval: int = 8 * 1024 * 1024
+    if progress is not None:
+        progress.step("compare", 0, progress_total, bytes_processed=0)
+
+    for rel in common:
         inode = inodes[file_inodes[rel]]
         # Hash the decoded image payload and the source file by streaming both.
         image_hash = hashlib.sha256()
         try:
             for chunk in iter_inode_logical_blocks(fh, header, inode, ekpfs=ekpfs, new_crypt=new_crypt):
                 image_hash.update(chunk)
+                processed += len(chunk)
+                if progress is not None and processed - last_reported >= update_interval:
+                    last_reported = processed
+                    progress.step("compare", min(processed, total_bytes), progress_total, bytes_processed=processed)
         except (ValueError, OSError) as exc:
             errors.append(f"file '{rel}' marked compressed but failed to decode payload: {exc}")
             continue
@@ -4573,6 +4606,9 @@ def validate_source_match(
 
         if image_hash.digest() != source_hash.digest():
             errors.append(f"content mismatch for file: {rel}")
+
+    if progress is not None:
+        progress.step("compare", progress_total, progress_total, bytes_processed=total_bytes)
 
 
 @dataclass

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -3117,6 +3117,341 @@ def build_pfs(
     return stats
 
 
+def build_pfs_stream_single_file(
+    *,
+    source_file: Path,
+    output_path: Path,
+    block_size: int,
+    pfs_version: int,
+    case_insensitive: bool,
+    zlib_level: int,
+    threshold_gain: int,
+    min_file_gain: int,
+    min_compress_size: int,
+    cpu_count: int,
+    compress: bool,
+    encrypted: bool = False,
+    new_crypt: bool = False,
+    ekpfs: bytes | None = None,
+    verbose: bool = False,
+) -> BuildStats:
+    """Build an unsigned PFS container from one file, streaming the payload with no spool.
+
+    Writes provisional front metadata, streams the file's PFSC payload directly into
+    its final block region in a single compression pass, then back-patches the file
+    inode and the header total-block count and truncates. Output is byte-identical to
+    the spool path for the same input.
+
+    Args:
+        source_file: Existing single source file to pack.
+        output_path: Final image path.
+        block_size: Filesystem block size in bytes.
+        pfs_version: PFS profile version.
+        case_insensitive: Whether to set the case-insensitive mode bit.
+        zlib_level: zlib compression level.
+        threshold_gain: Minimum per-block gain percent to keep PFSC blocks.
+        min_file_gain: Minimum whole-file gain percent required to store PFSC.
+        min_compress_size: Minimum raw size eligible for PFSC.
+        cpu_count: Requested CPU budget for block-level compression.
+        compress: Whether PFSC compression is enabled.
+        encrypted: Whether to encrypt filesystem blocks.
+        new_crypt: Whether to use the alternate EKPFS derivation.
+        ekpfs: Optional EKPFS key bytes.
+        verbose: Whether to emit a verbose per-file decision line.
+
+    Returns:
+        Build statistics for the completed image.
+
+    Raises:
+        BuildError: If the source is missing or an unexpected FPT collision occurs.
+    """
+    start: float = time.time()
+    progress: Progress = Progress(enabled=True)
+    if not source_file.is_file():
+        raise BuildError(f"source file does not exist: {source_file}")
+    raw_size: int = source_file.stat().st_size
+    now: int = int(time.time())
+    resolved_ekpfs: bytes = resolve_ekpfs_key(ekpfs=ekpfs)
+    seed: bytes = consts.ZERO_PFS_SEED
+
+    # Build the four unsigned inodes (super_root, fpt, uroot, file).
+    super_root_inode = Inode(
+        number=0,
+        mode=consts.INODE_MODE_DIR | consts.INODE_RX_ONLY,
+        nlink=1,
+        flags=consts.INODE_FLAG_INTERNAL | consts.INODE_FLAG_READONLY,
+        size=block_size,
+        size_compressed=block_size,
+        blocks=1,
+        time_sec=now,
+    )
+    fpt_inode = Inode(
+        number=1,
+        mode=consts.INODE_MODE_FILE | consts.INODE_RX_ONLY,
+        nlink=1,
+        flags=consts.INODE_FLAG_INTERNAL | consts.INODE_FLAG_READONLY,
+        size=0,
+        size_compressed=0,
+        blocks=1,
+        time_sec=now,
+    )
+    uroot_inode = Inode(
+        number=2,
+        mode=consts.INODE_MODE_DIR | consts.INODE_RX_ONLY,
+        nlink=3,
+        flags=consts.INODE_FLAG_READONLY,
+        size=block_size,
+        size_compressed=block_size,
+        blocks=1,
+        time_sec=now,
+    )
+    file_inode = Inode(
+        number=3,
+        mode=consts.INODE_MODE_FILE | consts.INODE_RX_ONLY,
+        nlink=1,
+        flags=consts.INODE_FLAG_READONLY,
+        size=0,
+        size_compressed=0,
+        blocks=1,
+        time_sec=now,
+    )
+    inodes: list[Inode] = [super_root_inode, fpt_inode, uroot_inode, file_inode]
+
+    # Synthesize the single-file directory model and the flat path table.
+    file_node = FileNode(
+        rel_path=source_file.name,
+        abs_path=source_file,
+        parent_rel_dir="",
+        name=source_file.name,
+        raw_size=raw_size,
+    )
+    file_node.inode = file_inode
+    uroot_dir = DirNode(rel_dir="", name="", parent_rel_dir=None, children_files=[source_file.name])
+    uroot_dir.inode = uroot_inode
+    inode_by_path: dict[str, Inode] = {"dir:": uroot_inode, f"file:{source_file.name}": file_inode}
+    fpt_blob: bytes
+    has_collision: bool
+    fpt_blob, _collision_blob, has_collision = make_fpt_and_collision_blob(
+        [uroot_dir],
+        [file_node],
+        inode_by_path,
+        case_insensitive=case_insensitive,
+    )
+    if has_collision:
+        raise BuildError("unexpected FPT collision in single-file streaming builder")
+
+    uroot_dirents: list[Dirent] = [
+        Dirent(uroot_inode.number, consts.DIRENT_TYPE_DOT, "."),
+        Dirent(uroot_inode.number, consts.DIRENT_TYPE_DOTDOT, ".."),
+        Dirent(file_inode.number, consts.DIRENT_TYPE_FILE, source_file.name),
+    ]
+    uroot_blob: bytes = b"".join(d.to_bytes() for d in uroot_dirents)
+    super_root_dirents: list[Dirent] = [
+        Dirent(fpt_inode.number, consts.DIRENT_TYPE_FILE, "flat_path_table"),
+        Dirent(uroot_inode.number, consts.DIRENT_TYPE_DIRECTORY, "uroot"),
+    ]
+
+    inode_count: int = len(inodes)
+    inode_size: int = consts.INODE_D32_SIZE
+    inodes_per_block: int = block_size // inode_size
+    inode_block_count: int = ceil_div(inode_count, inodes_per_block)
+
+    # Front layout (unsigned, contiguous). file.db[0] is known without the payload size.
+    ndblock: int = 1 + inode_block_count
+    super_root_inode.db[0] = ndblock
+    ndblock += super_root_inode.blocks
+    fpt_inode.size = len(fpt_blob)
+    fpt_inode.size_compressed = len(fpt_blob)
+    fpt_inode.blocks = max(1, ceil_div(len(fpt_blob), block_size))
+    fpt_inode.db[0] = ndblock
+    for i in range(1, consts.MAX_DIRECT_BLOCKS):
+        fpt_inode.db[i] = -1
+    ndblock += fpt_inode.blocks
+    ndblock += 1  # reserved empty block (no collision resolver)
+    reserved_empty_blocks: set[int] = {ndblock - 1}
+    uroot_inode.blocks = max(1, ceil_div(len(uroot_blob), block_size))
+    uroot_inode.size = uroot_inode.blocks * block_size
+    uroot_inode.size_compressed = uroot_inode.size
+    uroot_inode.db[0] = ndblock
+    for i in range(1, consts.MAX_DIRECT_BLOCKS):
+        uroot_inode.db[i] = -1
+    ndblock += uroot_inode.blocks
+    file_inode.db[0] = ndblock
+    for i in range(1, consts.MAX_DIRECT_BLOCKS):
+        file_inode.db[i] = -1
+    payload_base: int = file_inode.db[0] * block_size
+
+    mode: int = compose_pfs_mode_with_options(
+        inode_bits=32,
+        case_insensitive=case_insensitive,
+        signed=False,
+        encrypted=encrypted,
+    )
+
+    progress.status(f"\nWriting PFS image to {output_path} (streaming, no spool)...")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Path = Path(str(output_path) + ".tmp")
+    stored_size: int = raw_size
+    is_compressed: bool = False
+    gain_pct: float = 0.0
+    hypothetical_size: int = 0
+    try:
+        with tmp_path.open("w+b") as out:
+            # Provisional metadata; final_ndblock and the file inode are patched after streaming.
+            out.write(
+                _pack_pfs_header_block(
+                    block_size=block_size,
+                    pfs_version=pfs_version,
+                    mode=mode,
+                    nblock=1,
+                    inode_count=inode_count,
+                    final_ndblock=0,
+                    inode_block_count=inode_block_count,
+                    now=now,
+                    signed=False,
+                    encrypted=encrypted,
+                    seed=seed,
+                )
+            )
+            out.seek(block_size)
+            _write_inode_table(
+                out=out,
+                inodes=inodes,
+                signed=False,
+                signed_inode_bits=32,
+                block_size=block_size,
+                inode_size=inode_size,
+            )
+            out.seek(super_root_inode.db[0] * block_size)
+            for d in super_root_dirents:
+                out.write(d.to_bytes())
+            out.seek(fpt_inode.db[0] * block_size)
+            out.write(fpt_blob)
+            out.seek(uroot_inode.db[0] * block_size)
+            out.write(uroot_blob)
+
+            # Stream the payload directly into its final region (single compression pass).
+            total_units: int = max(raw_size, 1)
+            processed: int = 0
+
+            def report(delta: int) -> None:
+                """Forward block progress to the write phase bar."""
+                nonlocal processed
+                processed += delta
+                progress.step("write", min(processed, total_units), total_units, bytes_processed=processed)
+
+            if compress and raw_size > 0 and raw_size >= min_compress_size:
+                block_workers: int = resolve_block_compression_worker_count(
+                    requested_cpu_count=resolve_compression_worker_count(requested_cpu_count=cpu_count),
+                    file_size=raw_size,
+                )
+                stored_size, is_compressed, gain_pct, hypothetical_size = _encode_pfsc_into_handle(
+                    out=out,
+                    base_offset=payload_base,
+                    source_path=source_file,
+                    threshold_gain=threshold_gain,
+                    min_file_gain=min_file_gain,
+                    zlib_level=zlib_level,
+                    logical_block_size=consts.PFSC_LOGICAL_BLOCK_SIZE,
+                    block_worker_count=block_workers,
+                    progress_callback=report,
+                )
+
+            # Disabled, too small, or not worth compressing: store raw over the same region.
+            if not is_compressed:
+                write_source_to_offset(
+                    out=out,
+                    source_path=source_file,
+                    payload_size=raw_size,
+                    offset=payload_base,
+                )
+                stored_size = raw_size
+
+            # Finalize sizes and back-patch metadata.
+            file_inode.blocks = max(1, ceil_div(stored_size, block_size)) if stored_size > 0 else 1
+            file_inode.size = stored_size
+            file_inode.flags = consts.INODE_FLAG_READONLY | (consts.INODE_FLAG_COMPRESSED if is_compressed else 0)
+            file_inode.size_compressed = raw_size if is_compressed else stored_size
+            final_ndblock: int = file_inode.db[0] + file_inode.blocks
+
+            validate_d32_ranges(inodes, final_ndblock)
+
+            out.seek(0)
+            out.write(
+                _pack_pfs_header_block(
+                    block_size=block_size,
+                    pfs_version=pfs_version,
+                    mode=mode,
+                    nblock=1,
+                    inode_count=inode_count,
+                    final_ndblock=final_ndblock,
+                    inode_block_count=inode_block_count,
+                    now=now,
+                    signed=False,
+                    encrypted=encrypted,
+                    seed=seed,
+                )
+            )
+            out.seek(block_size)
+            _write_inode_table(
+                out=out,
+                inodes=inodes,
+                signed=False,
+                signed_inode_bits=32,
+                block_size=block_size,
+                inode_size=inode_size,
+            )
+            out.truncate(final_ndblock * block_size)
+
+            if encrypted:
+                encrypt_image_filesystem(
+                    out,
+                    block_size=block_size,
+                    total_blocks=final_ndblock,
+                    ekpfs=resolved_ekpfs,
+                    seed=seed,
+                    new_crypt=new_crypt,
+                    skip_block_numbers=reserved_empty_blocks,
+                )
+
+        validate_image_quick(
+            tmp_path,
+            block_size,
+            mode,
+            pfs_version,
+            ekpfs=resolved_ekpfs if encrypted else None,
+            new_crypt=new_crypt,
+        )
+        shutil.move(str(tmp_path), str(output_path))
+        progress.status(f"Successfully wrote {human_readable_size(final_ndblock * block_size)} image")
+    except Exception:
+        # Remove the partial temp image on any failure, then re-raise the original error.
+        if tmp_path.exists():
+            with suppress(FileNotFoundError):
+                tmp_path.unlink()
+        raise
+
+    stats = BuildStats(input_path=source_file, output_path=output_path)
+    stats.total_files = 1
+    stats.uncompressed_total_size = raw_size
+    stats.stored_total_size = stored_size
+    stats.all_compressed_total_size = hypothetical_size
+    stats.compressed_files = 1 if is_compressed else 0
+    stats.uncompressed_files = 0 if is_compressed else 1
+    stats.block_size = block_size
+    stats.block_alignment_waste = (
+        (ceil_div(stored_size, block_size) * block_size - stored_size) if stored_size > 0 else block_size
+    )
+    stats.elapsed_seconds = time.time() - start
+    if verbose:
+        state: str = "compressed" if is_compressed else "raw"
+        info(
+            f"[file] {source_file.name}: raw={raw_size} stored={stored_size} gain={gain_pct:.2f}% mode={state}",
+            icon_name="file",
+        )
+    return stats
+
+
 def validate_image_quick(
     image_path: Path,
     expected_block_size: int,

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -1604,22 +1604,20 @@ def _compress_files_in_process(
         )
 
 
-def decode_pfsc_payload(payload: bytes, expected_logical_size: int | None = None) -> bytes:
-    """Decode PFSC block-compressed payload bytes.
+def _parse_pfsc_header(head: bytes) -> tuple[int, int, int, int, int]:
+    """Parse and validate the fixed PFSC header fields.
 
     Args:
-        payload: Stored PFSC payload bytes.
-        expected_logical_size: Optional expected logical size from inode metadata.
+        head: At least ``PFSC_HEADER_SIZE`` bytes from the start of a PFSC payload.
 
     Returns:
-        Decoded logical file payload.
+        Tuple ``(logical_block_size, block_count, block_offsets_offset, data_offset, logical_size)``.
 
     Raises:
-        ValueError: If PFSC payload structure or per-block decoding is invalid.
+        ValueError: If any PFSC header field is invalid.
     """
-    if len(payload) < consts.PFSC_HEADER_SIZE:
+    if len(head) < consts.PFSC_HEADER_SIZE:
         raise ValueError("PFSC payload is too small for header")
-
     magic: int
     unk4: int
     unk8: int
@@ -1637,7 +1635,7 @@ def decode_pfsc_payload(payload: bytes, expected_logical_size: int | None = None
         block_offsets_offset,
         data_offset,
         logical_size,
-    ) = struct.unpack_from("<iiiiqqQq", payload, 0)
+    ) = struct.unpack_from("<iiiiqqQq", head, 0)
 
     if magic != consts.PFSC_MAGIC:
         raise ValueError(f"invalid PFSC magic 0x{magic:08X}")
@@ -1664,10 +1662,57 @@ def decode_pfsc_payload(payload: bytes, expected_logical_size: int | None = None
         )
     if data_offset < consts.PFSC_INITIAL_DATA_OFFSET:
         raise ValueError("PFSC data offset is smaller than the minimum compatible header span")
+
+    block_count: int = logical_size // logical_block_size
+    return logical_block_size, block_count, block_offsets_offset, data_offset, logical_size
+
+
+def _decode_pfsc_block(stored_block: bytes, logical_block_size: int, idx: int) -> bytes:
+    """Decode one stored PFSC block to its logical bytes.
+
+    Args:
+        stored_block: Stored block bytes (compressed when shorter than the logical size).
+        logical_block_size: Expected logical block size.
+        idx: Block index, used for error messages.
+
+    Returns:
+        Logical block bytes of length ``logical_block_size``.
+
+    Raises:
+        ValueError: If the block fails to decompress or has an unexpected size.
+    """
+    if len(stored_block) == logical_block_size:
+        return stored_block
+    if len(stored_block) < logical_block_size:
+        try:
+            logical_block: bytes = zlib.decompress(stored_block)
+        except zlib.error as exc:
+            raise ValueError(f"PFSC block {idx} failed to decompress: {exc}") from exc
+        if len(logical_block) != logical_block_size:
+            raise ValueError(
+                f"PFSC block {idx} decompressed to {len(logical_block)} bytes, expected {logical_block_size}"
+            )
+        return logical_block
+    raise ValueError(f"PFSC block {idx} stored size {len(stored_block)} exceeds logical size {logical_block_size}")
+
+
+def decode_pfsc_payload(payload: bytes, expected_logical_size: int | None = None) -> bytes:
+    """Decode PFSC block-compressed payload bytes.
+
+    Args:
+        payload: Stored PFSC payload bytes.
+        expected_logical_size: Optional expected logical size from inode metadata.
+
+    Returns:
+        Decoded logical file payload.
+
+    Raises:
+        ValueError: If PFSC payload structure or per-block decoding is invalid.
+    """
+    logical_block_size, block_count, block_offsets_offset, data_offset, logical_size = _parse_pfsc_header(payload)
     if data_offset > len(payload):
         raise ValueError("PFSC data offset exceeds payload length")
 
-    block_count: int = logical_size // logical_block_size
     offsets_size: int = (block_count + 1) * consts.PFSC_OFFSET_ENTRY_SIZE
     offsets_end: int = block_offsets_offset + offsets_size
     if offsets_end > data_offset or offsets_end > len(payload):
@@ -1683,29 +1728,9 @@ def decode_pfsc_payload(payload: bytes, expected_logical_size: int | None = None
             raise ValueError("PFSC block offsets are not monotonic")
 
     logical_out: bytearray = bytearray()
-
     for idx in range(block_count):
-        start: int = offsets[idx]
-        end: int = offsets[idx + 1]
-        stored_block: bytes = payload[start:end]
-        block_expected_size: int = logical_block_size
-
-        if len(stored_block) == block_expected_size:
-            logical_block: bytes = stored_block
-        elif len(stored_block) < block_expected_size:
-            try:
-                logical_block = zlib.decompress(stored_block)
-            except zlib.error as exc:
-                raise ValueError(f"PFSC block {idx} failed to decompress: {exc}") from exc
-            if len(logical_block) != block_expected_size:
-                raise ValueError(
-                    f"PFSC block {idx} decompressed to {len(logical_block)} bytes, expected {block_expected_size}"
-                )
-        else:
-            raise ValueError(
-                f"PFSC block {idx} stored size {len(stored_block)} exceeds logical size {block_expected_size}"
-            )
-        logical_out.extend(logical_block)
+        stored_block: bytes = payload[offsets[idx] : offsets[idx + 1]]
+        logical_out.extend(_decode_pfsc_block(stored_block, logical_block_size, idx))
 
     logical_payload: bytes = bytes(logical_out)
     if len(logical_payload) != logical_size:
@@ -4043,6 +4068,100 @@ def read_image_inode_payload(
     return data
 
 
+def iter_inode_logical_blocks(
+    fh: BinaryIO,
+    header: ParsedHeader,
+    inode: ParsedInode,
+    ekpfs: bytes | None = None,
+    new_crypt: bool = False,
+    chunk_size: int = 4 * 1024 * 1024,
+) -> Iterator[bytes]:
+    """Yield an inode's logical payload in bounded-memory chunks.
+
+    Streams the decoded payload without ever holding the whole file in memory:
+    for unsigned PFSC payloads it reads and decompresses one logical block at a
+    time; for unsigned raw payloads it copies fixed-size chunks; signed payloads
+    (size-limited by the signed layout) fall back to a single buffered decode.
+
+    Args:
+        fh: Open image file handle.
+        header: Parsed image header.
+        inode: Parsed inode whose payload should be streamed.
+        ekpfs: Optional EKPFS key material. Defaults to the all-zero key.
+        new_crypt: When True, use the alternate newCrypt key derivation path.
+        chunk_size: Read chunk size for raw (uncompressed) payloads.
+
+    Yields:
+        Logical payload byte chunks in order; concatenation equals the decoded file.
+
+    Raises:
+        ValueError: If the stored payload structure is invalid.
+    """
+    if inode.blocks <= 0 or inode.logical_size <= 0:
+        return
+
+    # Signed payloads are bounded by the signed-layout size limit; decode buffered.
+    if inode.db_sig or inode.ib_sig:
+        payload: bytes = read_image_inode_payload(fh, header, inode, ekpfs=ekpfs, new_crypt=new_crypt)
+        yield decode_inode_payload(payload=payload, inode=inode)
+        return
+
+    base: int = inode.db[0] * header.block_size
+    expected: int = inode.logical_size
+
+    # Raw (uncompressed) contiguous payload: stored bytes equal logical bytes.
+    if not inode.is_compressed:
+        remaining: int = expected
+        offset: int = base
+        while remaining > 0:
+            take: int = min(chunk_size, remaining)
+            yield read_image_bytes(fh, header, offset, take, ekpfs=ekpfs, new_crypt=new_crypt)
+            offset += take
+            remaining -= take
+        return
+
+    # Compressed PFSC payload stored contiguously from ``base``.
+    stored_size: int = inode.stored_size
+    head: bytes = read_image_bytes(fh, header, base, consts.PFSC_HEADER_SIZE, ekpfs=ekpfs, new_crypt=new_crypt)
+    logical_block_size, block_count, block_offsets_offset, data_offset, pfsc_logical_size = _parse_pfsc_header(head)
+    if data_offset > stored_size:
+        raise ValueError("PFSC data offset exceeds stored payload length")
+    offsets_size: int = (block_count + 1) * consts.PFSC_OFFSET_ENTRY_SIZE
+    if block_offsets_offset + offsets_size > data_offset or block_offsets_offset + offsets_size > stored_size:
+        raise ValueError("PFSC payload is truncated before block offset table")
+
+    offset_table: bytes = read_image_bytes(
+        fh, header, base + block_offsets_offset, offsets_size, ekpfs=ekpfs, new_crypt=new_crypt
+    )
+    offsets: list[int] = list(struct.unpack_from(f"<{block_count + 1}Q", offset_table, 0))
+    if offsets[0] != data_offset:
+        raise ValueError("PFSC block offsets must start at data_start")
+    if offsets[-1] > stored_size:
+        raise ValueError("PFSC block offsets exceed payload size")
+    for idx in range(1, len(offsets)):
+        if offsets[idx] < offsets[idx - 1]:
+            raise ValueError("PFSC block offsets are not monotonic")
+    if expected > pfsc_logical_size:
+        raise ValueError(f"PFSC logical size {pfsc_logical_size} is smaller than inode size {expected}")
+
+    # Read, decompress, and emit one logical block at a time, trimming to the file size.
+    emitted: int = 0
+    for idx in range(block_count):
+        if emitted >= expected:
+            break
+        stored_block: bytes = read_image_bytes(
+            fh, header, base + offsets[idx], offsets[idx + 1] - offsets[idx], ekpfs=ekpfs, new_crypt=new_crypt
+        )
+        logical_block: bytes = _decode_pfsc_block(stored_block, logical_block_size, idx)
+        if emitted + len(logical_block) > expected:
+            logical_block = logical_block[: expected - emitted]
+        emitted += len(logical_block)
+        yield logical_block
+
+    if emitted != expected:
+        raise ValueError(f"PFSC streamed output size {emitted} does not match inode size {expected}")
+
+
 def parse_superroot_and_indexes(
     fh: BinaryIO,
     header: ParsedHeader,
@@ -4243,25 +4362,24 @@ def verify_file_payload_hashes(
     for rel in sorted(file_inodes.keys()):
         inode_num = file_inodes[rel]
         inode = inodes[inode_num]
+        # Stream the logical payload one block at a time to keep memory flat.
+        file_hash = hashlib.sha256()
+        file_len = 0
         try:
-            payload = read_image_inode_payload(fh, header, inode, ekpfs=ekpfs, new_crypt=new_crypt)
-        except Exception as exc:
+            for chunk in iter_inode_logical_blocks(fh, header, inode, ekpfs=ekpfs, new_crypt=new_crypt):
+                file_hash.update(chunk)
+                cumulative_crc = zlib.crc32(chunk, cumulative_crc) & 0xFFFFFFFF
+                file_len += len(chunk)
+        except (ValueError, OSError) as exc:
             errors.append(f"failed to read file payload '{rel}' (inode {inode_num}): {exc}")
             continue
 
-        try:
-            logical_data = decode_inode_payload(payload=payload, inode=inode)
-        except ValueError as exc:
-            errors.append(f"file '{rel}' payload decode failed: {exc}")
-            continue
-        if inode.logical_size >= 0 and len(logical_data) != inode.logical_size:
-            errors.append(f"file '{rel}' size {len(logical_data)} does not match inode size {inode.logical_size}")
+        if inode.logical_size >= 0 and file_len != inode.logical_size:
+            errors.append(f"file '{rel}' size {file_len} does not match inode size {inode.logical_size}")
 
-        file_hash = hashlib.sha256(logical_data).digest()
         manifest.update(rel.encode("utf-8", errors="replace"))
         manifest.update(b"\0")
-        manifest.update(file_hash)
-        cumulative_crc = zlib.crc32(logical_data, cumulative_crc) & 0xFFFFFFFF
+        manifest.update(file_hash.digest())
         checked += 1
 
     return checked, cumulative_crc, manifest.hexdigest()
@@ -4436,16 +4554,24 @@ def validate_source_match(
 
     for rel in sorted(source_rel & image_rel):
         inode = inodes[file_inodes[rel]]
-        payload = read_image_inode_payload(fh, header, inode, ekpfs=ekpfs, new_crypt=new_crypt)
-        if inode.is_compressed:
-            try:
-                payload = decode_inode_payload(payload=payload, inode=inode)
-            except ValueError as exc:
-                errors.append(f"file '{rel}' marked compressed but failed to decode payload: {exc}")
-                continue
+        # Hash the decoded image payload and the source file by streaming both.
+        image_hash = hashlib.sha256()
+        try:
+            for chunk in iter_inode_logical_blocks(fh, header, inode, ekpfs=ekpfs, new_crypt=new_crypt):
+                image_hash.update(chunk)
+        except (ValueError, OSError) as exc:
+            errors.append(f"file '{rel}' marked compressed but failed to decode payload: {exc}")
+            continue
 
-        src_data = (source / rel).read_bytes()
-        if hashlib.sha256(src_data).digest() != hashlib.sha256(payload).digest():
+        source_hash = hashlib.sha256()
+        with (source / rel).open("rb") as src_fh:
+            while True:
+                src_chunk: bytes = src_fh.read(4 * 1024 * 1024)
+                if not src_chunk:
+                    break
+                source_hash.update(src_chunk)
+
+        if image_hash.digest() != source_hash.digest():
             errors.append(f"content mismatch for file: {rel}")
 
 
@@ -4867,18 +4993,20 @@ def extract_pfs_image(
             total_files: int = len(file_targets)
             for index, (rel_path, file_target, inode_num) in enumerate(file_targets, start=1):
                 inode: ParsedInode = inspection.inodes[inode_num]
-                payload = read_image_inode_payload(fh, inspection.header, inode, ekpfs=ekpfs, new_crypt=new_crypt)
-                if inode.is_compressed:
-                    try:
-                        payload = decode_inode_payload(payload=payload, inode=inode)
-                    except ValueError as exc:
-                        result.errors.append(f"failed to decode file '{rel_path}' payload: {exc}")
-                        return result
-
                 file_target.parent.mkdir(parents=True, exist_ok=True)
-                file_target.write_bytes(payload)
+                # Stream logical blocks straight to disk to keep memory flat for large files.
+                try:
+                    with file_target.open("wb") as out_fh:
+                        for chunk in iter_inode_logical_blocks(
+                            fh, inspection.header, inode, ekpfs=ekpfs, new_crypt=new_crypt
+                        ):
+                            out_fh.write(chunk)
+                            result.bytes_written += len(chunk)
+                except ValueError as exc:
+                    result.errors.append(f"failed to decode file '{rel_path}' payload: {exc}")
+                    return result
+
                 result.files_written += 1
-                result.bytes_written += len(payload)
 
                 if progress is not None:
                     progress.step("extract", index, total_files, bytes_processed=result.bytes_written)

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -3142,6 +3142,57 @@ def build_pfs(
     return stats
 
 
+def _single_file_build_stats(
+    *,
+    source_file: Path,
+    output_path: Path,
+    raw_size: int,
+    stored_size: int,
+    is_compressed: bool,
+    hypothetical_size: int,
+    block_size: int,
+    gain_pct: float,
+    elapsed_seconds: float,
+    verbose: bool,
+) -> BuildStats:
+    """Build single-file pack statistics shared by the dry-run and write paths.
+
+    Args:
+        source_file: Source file packed.
+        output_path: Output image path.
+        raw_size: Raw file size in bytes.
+        stored_size: Stored payload size in bytes.
+        is_compressed: Whether the payload is stored PFSC-compressed.
+        hypothetical_size: Hypothetical all-blocks-compressed size.
+        block_size: Filesystem block size in bytes.
+        gain_pct: Effective whole-file gain percent, used for the verbose line.
+        elapsed_seconds: Elapsed build time in seconds.
+        verbose: Whether to emit the per-file decision line.
+
+    Returns:
+        Populated build statistics for the single-file pack.
+    """
+    stats = BuildStats(input_path=source_file, output_path=output_path)
+    stats.total_files = 1
+    stats.uncompressed_total_size = raw_size
+    stats.stored_total_size = stored_size
+    stats.all_compressed_total_size = hypothetical_size
+    stats.compressed_files = 1 if is_compressed else 0
+    stats.uncompressed_files = 0 if is_compressed else 1
+    stats.block_size = block_size
+    stats.block_alignment_waste = (
+        (ceil_div(stored_size, block_size) * block_size - stored_size) if stored_size > 0 else block_size
+    )
+    stats.elapsed_seconds = elapsed_seconds
+    if verbose:
+        state: str = "compressed" if is_compressed else "raw"
+        info(
+            f"[file] {source_file.name}: raw={raw_size} stored={stored_size} gain={gain_pct:.2f}% mode={state}",
+            icon_name="file",
+        )
+    return stats
+
+
 def build_pfs_stream_single_file(
     *,
     source_file: Path,
@@ -3159,6 +3210,8 @@ def build_pfs_stream_single_file(
     new_crypt: bool = False,
     ekpfs: bytes | None = None,
     verbose: bool = False,
+    skip_executable_compression: bool = False,
+    dry_run: bool = False,
 ) -> BuildStats:
     """Build an unsigned PFS container from one file, streaming the payload with no spool.
 
@@ -3183,6 +3236,8 @@ def build_pfs_stream_single_file(
         new_crypt: Whether to use the alternate EKPFS derivation.
         ekpfs: Optional EKPFS key bytes.
         verbose: Whether to emit a verbose per-file decision line.
+        skip_executable_compression: Whether to store executable-like files raw.
+        dry_run: When True, report the layout and stats without writing an image.
 
     Returns:
         Build statistics for the completed image.
@@ -3198,6 +3253,44 @@ def build_pfs_stream_single_file(
     now: int = int(time.time())
     resolved_ekpfs: bytes = resolve_ekpfs_key(ekpfs=ekpfs)
     seed: bytes = consts.ZERO_PFS_SEED
+
+    # Decide whether this file is eligible for PFSC compression at all.
+    should_compress: bool = (
+        compress
+        and raw_size > 0
+        and raw_size >= min_compress_size
+        and not (skip_executable_compression and should_skip_executable_compression(source_file.name))
+    )
+    block_workers: int = resolve_block_compression_worker_count(
+        requested_cpu_count=resolve_compression_worker_count(requested_cpu_count=cpu_count),
+        file_size=raw_size,
+    )
+
+    # Dry run: measure the storage decision and report stats without writing.
+    if dry_run:
+        if should_compress:
+            dry_stored, dry_compressed, dry_gain, dry_hyp = _analyze_pfsc_file_storage(
+                abs_path=source_file,
+                threshold_gain=threshold_gain,
+                min_file_gain=min_file_gain,
+                zlib_level=zlib_level,
+                logical_block_size=consts.PFSC_LOGICAL_BLOCK_SIZE,
+                block_worker_count=block_workers,
+            )
+        else:
+            dry_stored, dry_compressed, dry_gain, dry_hyp = raw_size, False, 0.0, 0
+        return _single_file_build_stats(
+            source_file=source_file,
+            output_path=output_path,
+            raw_size=raw_size,
+            stored_size=dry_stored,
+            is_compressed=dry_compressed,
+            hypothetical_size=dry_hyp,
+            block_size=block_size,
+            gain_pct=dry_gain,
+            elapsed_seconds=time.time() - start,
+            verbose=verbose,
+        )
 
     # Build the four unsigned inodes (super_root, fpt, uroot, file).
     super_root_inode = Inode(
@@ -3365,11 +3458,7 @@ def build_pfs_stream_single_file(
                 processed += delta
                 progress.step("compress", min(processed, total_units), total_units, bytes_processed=processed)
 
-            if compress and raw_size > 0 and raw_size >= min_compress_size:
-                block_workers: int = resolve_block_compression_worker_count(
-                    requested_cpu_count=resolve_compression_worker_count(requested_cpu_count=cpu_count),
-                    file_size=raw_size,
-                )
+            if should_compress:
                 progress.status(
                     f"\nCompressing 1 file ({human_readable_size(raw_size)}) "
                     f"using {block_workers} CPU core{'s' if block_workers != 1 else ''}..."
@@ -3460,25 +3549,18 @@ def build_pfs_stream_single_file(
                 tmp_path.unlink()
         raise
 
-    stats = BuildStats(input_path=source_file, output_path=output_path)
-    stats.total_files = 1
-    stats.uncompressed_total_size = raw_size
-    stats.stored_total_size = stored_size
-    stats.all_compressed_total_size = hypothetical_size
-    stats.compressed_files = 1 if is_compressed else 0
-    stats.uncompressed_files = 0 if is_compressed else 1
-    stats.block_size = block_size
-    stats.block_alignment_waste = (
-        (ceil_div(stored_size, block_size) * block_size - stored_size) if stored_size > 0 else block_size
+    return _single_file_build_stats(
+        source_file=source_file,
+        output_path=output_path,
+        raw_size=raw_size,
+        stored_size=stored_size,
+        is_compressed=is_compressed,
+        hypothetical_size=hypothetical_size,
+        block_size=block_size,
+        gain_pct=gain_pct,
+        elapsed_seconds=time.time() - start,
+        verbose=verbose,
     )
-    stats.elapsed_seconds = time.time() - start
-    if verbose:
-        state: str = "compressed" if is_compressed else "raw"
-        info(
-            f"[file] {source_file.name}: raw={raw_size} stored={stored_size} gain={gain_pct:.2f}% mode={state}",
-            icon_name="file",
-        )
-    return stats
 
 
 def validate_image_quick(

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -2309,6 +2309,92 @@ def assign_signed_inode_layout(
     return next_block
 
 
+def _pack_pfs_header_block(
+    *,
+    block_size: int,
+    pfs_version: int,
+    mode: int,
+    nblock: int,
+    inode_count: int,
+    final_ndblock: int,
+    inode_block_count: int,
+    now: int,
+    signed: bool,
+    encrypted: bool,
+    seed: bytes,
+) -> bytes:
+    """Build the plaintext PFS header block (block 0).
+
+    Args:
+        block_size: Filesystem block size in bytes; length of the returned block.
+        pfs_version: PFS profile version.
+        mode: Composed PFS mode bits.
+        nblock: Number of leading blocks (always 1 today).
+        inode_count: Total inode count.
+        final_ndblock: Total data block count for the image.
+        inode_block_count: Number of inode blocks.
+        now: Build timestamp in seconds.
+        signed: Whether the image is signed.
+        encrypted: Whether the image is encrypted.
+        seed: PFS seed value.
+
+    Returns:
+        A ``block_size``-length header block.
+    """
+    hdr: bytearray = bytearray(block_size)
+    struct.pack_into("<q", hdr, 0x00, pfs_version)
+    struct.pack_into("<q", hdr, 0x08, consts.PFS_MAGIC)
+    struct.pack_into("<q", hdr, 0x10, 0)
+    struct.pack_into("<BBBB", hdr, 0x18, 0, 0, 1, 0)
+    struct.pack_into("<H", hdr, 0x1C, mode)
+    struct.pack_into("<H", hdr, 0x1E, 0)
+    struct.pack_into("<I", hdr, 0x20, block_size)
+    struct.pack_into("<I", hdr, 0x24, 0)
+    struct.pack_into("<q", hdr, 0x28, nblock)
+    struct.pack_into("<q", hdr, 0x30, inode_count)
+    struct.pack_into("<q", hdr, 0x38, final_ndblock)
+    struct.pack_into("<q", hdr, 0x40, inode_block_count)
+    ib_sig_bytes: bytes = build_inode_block_sig_s64(inode_block_count, block_size, now, signed=signed)
+    hdr[0x50 : 0x50 + len(ib_sig_bytes)] = ib_sig_bytes
+    if signed or encrypted:
+        struct.pack_into("<I", hdr, 0x36C, 1)
+        hdr[0x370 : 0x370 + len(seed)] = seed
+    else:
+        struct.pack_into("<I", hdr, 0x368, 1)
+    return bytes(hdr)
+
+
+def _write_inode_table(
+    *,
+    out: BinaryIO,
+    inodes: list[Inode],
+    signed: bool,
+    signed_inode_bits: int,
+    block_size: int,
+    inode_size: int,
+) -> None:
+    """Write the inode table starting at the current handle position.
+
+    Mirrors the per-block packing used by ``build_pfs``: when the remaining space
+    in the current block is smaller than one inode, skip to the next block.
+
+    Args:
+        out: Open writable and seekable handle positioned at the inode table start.
+        inodes: Inodes in image order.
+        signed: Whether to use the signed inode layout.
+        signed_inode_bits: Signed inode width (32 or 64) when ``signed``.
+        block_size: Filesystem block size.
+        inode_size: Serialized inode size in bytes.
+    """
+    for ino in inodes:
+        if signed:
+            out.write(ino.to_bytes_signed64() if signed_inode_bits == 64 else ino.to_bytes_signed32())
+        else:
+            out.write(ino.to_bytes())
+        if (out.tell() % block_size) > (block_size - inode_size):
+            out.seek(out.tell() + (block_size - (out.tell() % block_size)))
+
+
 def build_pfs(
     source_root: Path,
     output_path: Path,
@@ -2874,41 +2960,31 @@ def build_pfs(
         with tmp_path.open("w+b") as out:
             out.truncate(image_size)
 
-            hdr = bytearray(block_size)
-            struct.pack_into("<q", hdr, 0x00, pfs_version)
-            struct.pack_into("<q", hdr, 0x08, consts.PFS_MAGIC)
-            struct.pack_into("<q", hdr, 0x10, 0)
-            struct.pack_into("<BBBB", hdr, 0x18, 0, 0, 1, 0)
-            struct.pack_into("<H", hdr, 0x1C, mode)
-            struct.pack_into("<H", hdr, 0x1E, 0)
-            struct.pack_into("<I", hdr, 0x20, block_size)
-            struct.pack_into("<I", hdr, 0x24, 0)
-            struct.pack_into("<q", hdr, 0x28, nblock)
-            struct.pack_into("<q", hdr, 0x30, inode_count)
-            struct.pack_into("<q", hdr, 0x38, final_ndblock)
-            struct.pack_into("<q", hdr, 0x40, inode_block_count)
-            ib_sig_bytes = build_inode_block_sig_s64(inode_block_count, block_size, now, signed=signed)
-            hdr[0x50 : 0x50 + len(ib_sig_bytes)] = ib_sig_bytes
-            if signed or encrypted:
-                struct.pack_into("<I", hdr, 0x36C, 1)
-                hdr[0x370 : 0x370 + len(seed)] = seed
-            else:
-                struct.pack_into("<I", hdr, 0x368, 1)
-
+            hdr = _pack_pfs_header_block(
+                block_size=block_size,
+                pfs_version=pfs_version,
+                mode=mode,
+                nblock=nblock,
+                inode_count=inode_count,
+                final_ndblock=final_ndblock,
+                inode_block_count=inode_block_count,
+                now=now,
+                signed=signed,
+                encrypted=encrypted,
+                seed=seed,
+            )
             out.seek(0)
             out.write(hdr)
 
             out.seek(block_size)
-            for ino in inodes:
-                if signed:
-                    if signed_inode_bits == 64:
-                        out.write(ino.to_bytes_signed64())
-                    else:
-                        out.write(ino.to_bytes_signed32())
-                else:
-                    out.write(ino.to_bytes())
-                if (out.tell() % block_size) > (block_size - inode_size):
-                    out.seek(out.tell() + (block_size - (out.tell() % block_size)))
+            _write_inode_table(
+                out=out,
+                inodes=inodes,
+                signed=signed,
+                signed_inode_bits=signed_inode_bits,
+                block_size=block_size,
+                inode_size=inode_size,
+            )
 
             out.seek(block_size * (inode_block_count + 1))
             for d in super_root_dirents:

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -3335,15 +3335,19 @@ def build_pfs_stream_single_file(
             processed: int = 0
 
             def report(delta: int) -> None:
-                """Forward block progress to the write phase bar."""
+                """Forward block progress to the compression bar."""
                 nonlocal processed
                 processed += delta
-                progress.step("write", min(processed, total_units), total_units, bytes_processed=processed)
+                progress.step("compress", min(processed, total_units), total_units, bytes_processed=processed)
 
             if compress and raw_size > 0 and raw_size >= min_compress_size:
                 block_workers: int = resolve_block_compression_worker_count(
                     requested_cpu_count=resolve_compression_worker_count(requested_cpu_count=cpu_count),
                     file_size=raw_size,
+                )
+                progress.status(
+                    f"\nCompressing 1 file ({human_readable_size(raw_size)}) "
+                    f"using {block_workers} CPU core{'s' if block_workers != 1 else ''}..."
                 )
                 stored_size, is_compressed, gain_pct, hypothetical_size = _encode_pfsc_into_handle(
                     out=out,

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -1154,6 +1154,143 @@ def _analyze_pfsc_file_storage(
     return encoded_payload_size, True, effective_gain_pct, hypothetical_all_compressed_size
 
 
+def _encode_pfsc_into_handle(
+    *,
+    out: BinaryIO,
+    base_offset: int,
+    source_path: Path,
+    threshold_gain: int,
+    min_file_gain: int,
+    zlib_level: int,
+    logical_block_size: int,
+    block_worker_count: int = 1,
+    progress_callback: Callable[[int], None] | None = None,
+) -> tuple[int, bool, float, int]:
+    """Encode a file's PFSC payload directly into an open handle at ``base_offset``.
+
+    Streams one logical block at a time, recording block offsets, then seeks back
+    to ``base_offset`` to write the PFSC header and offset table. The caller owns
+    the handle's final size; this function never truncates.
+
+    Args:
+        out: Open writable and seekable binary handle.
+        base_offset: Absolute byte offset where the PFSC payload begins.
+        source_path: Source file path.
+        threshold_gain: Minimum per-block gain percent to keep compressed bytes.
+        min_file_gain: Minimum whole-file gain percent required to store PFSC.
+        zlib_level: zlib compression level.
+        logical_block_size: PFSC logical block size.
+        block_worker_count: Number of worker processes to use for block-level
+            compression of this file.
+        progress_callback: Optional callback receiving processed raw byte deltas.
+
+    Returns:
+        Tuple ``(stored_size, is_compressed, gain_pct, hypothetical_all_compressed_size)``.
+    """
+    raw_size: int = source_path.stat().st_size
+    if not (0 <= min_file_gain <= 100):
+        raise ValueError(f"min_file_gain must be between 0 and 100 inclusive, got {min_file_gain}")
+    if raw_size == 0:
+        return 0, False, 0.0, 0
+
+    block_count: int = ceil_div(raw_size, logical_block_size)
+    header_size: int = _pfsc_header_size(block_count=block_count, logical_block_size=logical_block_size)
+    offsets: list[int] = [header_size]
+    all_compressed_size: int = 0
+    compressed_blocks: int = 0
+    effective_block_workers: int = max(1, min(block_worker_count, block_count))
+
+    # Write payload blocks after the reserved header region for this payload.
+    out.seek(base_offset + header_size)
+    if effective_block_workers == 1:
+        with source_path.open("rb") as source_file:
+            for _idx in range(block_count):
+                chunk: bytes = source_file.read(logical_block_size)
+                padded_chunk: bytes = chunk.ljust(logical_block_size, b"\x00")
+                compressed_chunk: bytes = zlib.compress(padded_chunk, level=zlib_level)
+                all_compressed_size += len(compressed_chunk)
+                gain_pct: float = ((len(padded_chunk) - len(compressed_chunk)) / len(padded_chunk)) * 100.0
+                store_compressed: bool = _should_store_pfsc_block_compressed(
+                    compressed_block_size=len(compressed_chunk),
+                    logical_block_size=logical_block_size,
+                    gain_pct=gain_pct,
+                    threshold_gain=threshold_gain,
+                )
+                selected_chunk: bytes = compressed_chunk if store_compressed else padded_chunk
+                if store_compressed:
+                    compressed_blocks += 1
+                out.write(selected_chunk)
+                offsets.append(offsets[-1] + len(selected_chunk))
+                if progress_callback is not None:
+                    progress_callback(len(chunk))
+    else:
+        worker_args_iter: Iterator[tuple[Path, int, int, int]] = _iter_pfsc_block_worker_args(
+            abs_path=source_path,
+            block_count=block_count,
+            logical_block_size=logical_block_size,
+            zlib_level=zlib_level,
+        )
+        with mp.Pool(processes=effective_block_workers) as pool:
+            results_iter = pool.imap(_compress_pfsc_block_payload_worker, worker_args_iter, chunksize=1)
+            raw_chunk: bytes
+            compressed_chunk: bytes
+            for raw_chunk, compressed_chunk in results_iter:
+                padded_chunk: bytes = raw_chunk.ljust(logical_block_size, b"\x00")
+                all_compressed_size += len(compressed_chunk)
+                gain_pct: float = ((len(padded_chunk) - len(compressed_chunk)) / len(padded_chunk)) * 100.0
+                store_compressed: bool = _should_store_pfsc_block_compressed(
+                    compressed_block_size=len(compressed_chunk),
+                    logical_block_size=logical_block_size,
+                    gain_pct=gain_pct,
+                    threshold_gain=threshold_gain,
+                )
+                selected_chunk: bytes = compressed_chunk if store_compressed else padded_chunk
+                if store_compressed:
+                    compressed_blocks += 1
+                out.write(selected_chunk)
+                offsets.append(offsets[-1] + len(selected_chunk))
+                if progress_callback is not None:
+                    progress_callback(len(raw_chunk))
+
+    encoded_payload_size: int = offsets[-1]
+    hypothetical_all_compressed_size: int = header_size + all_compressed_size
+    if compressed_blocks == 0 or encoded_payload_size >= raw_size:
+        return raw_size, False, 0.0, hypothetical_all_compressed_size
+
+    effective_gain_pct: float = ((raw_size - encoded_payload_size) / raw_size) * 100.0
+    if effective_gain_pct < min_file_gain:
+        return raw_size, False, effective_gain_pct, hypothetical_all_compressed_size
+
+    # Backfill the PFSC header and block offset table at the payload base.
+    header: PFSCHeader = PFSCHeader(
+        magic=consts.PFSC_MAGIC,
+        unk4=consts.PFSC_UNK4,
+        unk8=consts.PFSC_UNK8,
+        logical_block_size=logical_block_size,
+        block_offsets_offset=consts.PFSC_BLOCK_OFFSETS_OFFSET,
+        data_offset=header_size,
+        data_length=block_count * logical_block_size,
+    )
+    header_area: bytearray = bytearray(header_size)
+    struct.pack_into(
+        "<iiiiqqQq",
+        header_area,
+        0,
+        header.magic,
+        header.unk4,
+        header.unk8,
+        header.logical_block_size,
+        header.logical_block_size,
+        header.block_offsets_offset,
+        header.data_offset,
+        header.data_length,
+    )
+    struct.pack_into(f"<{block_count + 1}Q", header_area, consts.PFSC_BLOCK_OFFSETS_OFFSET, *offsets)
+    out.seek(base_offset)
+    out.write(header_area)
+    return encoded_payload_size, True, effective_gain_pct, hypothetical_all_compressed_size
+
+
 def _encode_pfsc_file_to_spool(
     *,
     abs_path: Path,
@@ -1166,6 +1303,9 @@ def _encode_pfsc_file_to_spool(
     progress_callback: Callable[[int], None] | None = None,
 ) -> tuple[int, bool, float, int]:
     """Write a file's PFSC payload to a spool file using low-memory streaming.
+
+    Thin wrapper around :func:`_encode_pfsc_into_handle` that targets a fresh
+    spool file at offset zero and trims it to the encoded payload size.
 
     Args:
         abs_path: Source file path.
@@ -1181,109 +1321,24 @@ def _encode_pfsc_file_to_spool(
     Returns:
         Tuple ``(stored_size, is_compressed, gain_pct, hypothetical_all_compressed_size)``.
     """
-    raw_size: int = abs_path.stat().st_size
-    if not (0 <= min_file_gain <= 100):
-        raise ValueError(f"min_file_gain must be between 0 and 100 inclusive, got {min_file_gain}")
-    if raw_size == 0:
-        return 0, False, 0.0, 0
-
-    block_count: int = ceil_div(raw_size, logical_block_size)
-    header_size: int = _pfsc_header_size(block_count=block_count, logical_block_size=logical_block_size)
-    offsets: list[int] = [header_size]
-    all_compressed_size: int = 0
-    compressed_blocks: int = 0
-    effective_block_workers: int = max(1, min(block_worker_count, block_count))
-
     with spool_path.open("w+b") as spool_file:
-        spool_file.seek(header_size)
-        if effective_block_workers == 1:
-            with abs_path.open("rb") as source_file:
-                for _idx in range(block_count):
-                    chunk: bytes = source_file.read(logical_block_size)
-                    padded_chunk: bytes = chunk.ljust(logical_block_size, b"\x00")
-                    compressed_chunk: bytes = zlib.compress(padded_chunk, level=zlib_level)
-                    all_compressed_size += len(compressed_chunk)
-                    gain_pct: float = ((len(padded_chunk) - len(compressed_chunk)) / len(padded_chunk)) * 100.0
-                    store_compressed: bool = _should_store_pfsc_block_compressed(
-                        compressed_block_size=len(compressed_chunk),
-                        logical_block_size=logical_block_size,
-                        gain_pct=gain_pct,
-                        threshold_gain=threshold_gain,
-                    )
-                    selected_chunk: bytes = compressed_chunk if store_compressed else padded_chunk
-                    if store_compressed:
-                        compressed_blocks += 1
-                    spool_file.write(selected_chunk)
-                    offsets.append(offsets[-1] + len(selected_chunk))
-                    if progress_callback is not None:
-                        progress_callback(len(chunk))
-        else:
-            worker_args_iter: Iterator[tuple[Path, int, int, int]] = _iter_pfsc_block_worker_args(
-                abs_path=abs_path,
-                block_count=block_count,
-                logical_block_size=logical_block_size,
-                zlib_level=zlib_level,
-            )
-            with mp.Pool(processes=effective_block_workers) as pool:
-                results_iter = pool.imap(_compress_pfsc_block_payload_worker, worker_args_iter, chunksize=1)
-                raw_chunk: bytes
-                compressed_chunk: bytes
-                for raw_chunk, compressed_chunk in results_iter:
-                    padded_chunk: bytes = raw_chunk.ljust(logical_block_size, b"\x00")
-                    all_compressed_size += len(compressed_chunk)
-                    gain_pct: float = ((len(padded_chunk) - len(compressed_chunk)) / len(padded_chunk)) * 100.0
-                    store_compressed: bool = _should_store_pfsc_block_compressed(
-                        compressed_block_size=len(compressed_chunk),
-                        logical_block_size=logical_block_size,
-                        gain_pct=gain_pct,
-                        threshold_gain=threshold_gain,
-                    )
-                    selected_chunk: bytes = compressed_chunk if store_compressed else padded_chunk
-                    if store_compressed:
-                        compressed_blocks += 1
-                    spool_file.write(selected_chunk)
-                    offsets.append(offsets[-1] + len(selected_chunk))
-                    if progress_callback is not None:
-                        progress_callback(len(raw_chunk))
-
-        encoded_payload_size: int = offsets[-1]
-        hypothetical_all_compressed_size: int = header_size + all_compressed_size
-        if compressed_blocks == 0 or encoded_payload_size >= raw_size:
-            return raw_size, False, 0.0, hypothetical_all_compressed_size
-
-        effective_gain_pct: float = ((raw_size - encoded_payload_size) / raw_size) * 100.0
-        if effective_gain_pct < min_file_gain:
-            return raw_size, False, effective_gain_pct, hypothetical_all_compressed_size
-
-        header: PFSCHeader = PFSCHeader(
-            magic=consts.PFSC_MAGIC,
-            unk4=consts.PFSC_UNK4,
-            unk8=consts.PFSC_UNK8,
+        stored_size: int
+        is_compressed: bool
+        gain_pct: float
+        hypothetical_all_compressed_size: int
+        stored_size, is_compressed, gain_pct, hypothetical_all_compressed_size = _encode_pfsc_into_handle(
+            out=spool_file,
+            base_offset=0,
+            source_path=abs_path,
+            threshold_gain=threshold_gain,
+            min_file_gain=min_file_gain,
+            zlib_level=zlib_level,
             logical_block_size=logical_block_size,
-            block_offsets_offset=consts.PFSC_BLOCK_OFFSETS_OFFSET,
-            data_offset=header_size,
-            data_length=block_count * logical_block_size,
+            block_worker_count=block_worker_count,
+            progress_callback=progress_callback,
         )
-        header_area: bytearray = bytearray(header_size)
-        struct.pack_into(
-            "<iiiiqqQq",
-            header_area,
-            0,
-            header.magic,
-            header.unk4,
-            header.unk8,
-            header.logical_block_size,
-            header.logical_block_size,
-            header.block_offsets_offset,
-            header.data_offset,
-            header.data_length,
-        )
-        struct.pack_into(f"<{block_count + 1}Q", header_area, consts.PFSC_BLOCK_OFFSETS_OFFSET, *offsets)
-        spool_file.seek(0)
-        spool_file.write(header_area)
-        spool_file.truncate(encoded_payload_size)
-
-    return encoded_payload_size, True, effective_gain_pct, hypothetical_all_compressed_size
+        spool_file.truncate(stored_size)
+    return stored_size, is_compressed, gain_pct, hypothetical_all_compressed_size
 
 
 def _copy_exact_bytes(*, source_file: BinaryIO, destination_file: BinaryIO, byte_count: int, chunk_size: int) -> None:

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -1445,3 +1445,64 @@ class TestRunImageCheck(CliTestCase):
         self.assertTrue(any("CRC32 mismatch" in item for item in errors))
         self.assertTrue(any("Manifest SHA256 mismatch" in item for item in errors))
         self.assertTrue(any("orphan inodes" in item for item in errors))
+
+
+class TestCliPackFileNoSpool(CliTestCase):
+    """Tests for the spool-free streaming flag on the file pack path."""
+
+    def test_pack_file_no_spool_creates_image_without_spool(self) -> None:
+        """`pack file --no-spool` writes the image and leaves no spool in the temp folder."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "PPSA.exfat"
+        src.write_bytes(b"DATA" * 20000 + b"\x00" * 60000)
+        temp: Path = tmp_path / "temp"
+        temp.mkdir()
+        out: Path = tmp_path / "PPSA.ffpfsc"
+        buffer: StringIO = StringIO()
+        with patch.object(cli, "prompt_overwrite", return_value=True), redirect_stdout(buffer), redirect_stderr(
+            StringIO()
+        ):
+            rc: int = cli_mkpfs_main(
+                [
+                    "pack",
+                    "file",
+                    str(src),
+                    str(out),
+                    "--version",
+                    "PS5",
+                    "--inode-bits",
+                    "32",
+                    "--no-spool",
+                    "--temp-folder",
+                    str(temp),
+                    "--no-adjust-output-file-extension",
+                ]
+            )
+        self.assertEqual(rc, 0)
+        self.assertTrue(out.exists())
+        self.assertEqual(list(temp.glob("mkpfs-*.pfsc")), [])
+
+    def test_pack_file_no_spool_rejects_signed(self) -> None:
+        """Combining --no-spool with --signed is rejected."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "x.exfat"
+        src.write_bytes(b"x" * 1000)
+        out: Path = tmp_path / "x.ffpfsc"
+        with self.assertRaises(BuildError):
+            cli_mkpfs_main(
+                [
+                    "pack",
+                    "file",
+                    str(src),
+                    str(out),
+                    "--no-spool",
+                    "--signed",
+                    "--no-adjust-output-file-extension",
+                ]
+            )
+
+    def test_pack_folder_does_not_accept_no_spool(self) -> None:
+        """The --no-spool flag is only available on the file path, not the folder path."""
+        parser: argparse.ArgumentParser = cli.cli_mkpfs_main_parsers()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["pack", "folder", "src", "out", "--no-spool"])

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -1535,3 +1535,36 @@ class TestCliPackFileNoSpool(CliTestCase):
                 ]
             )
         self.assertEqual(rc, 0)
+
+    def test_pack_file_no_spool_prints_parameters_and_progress(self) -> None:
+        """The streaming path prints the parameters banner and a compression status line."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "PPSA.exfat"
+        src.write_bytes(b"GAMEDATA" * 20000 + b"\x00" * 200000)
+        out: Path = tmp_path / "PPSA.ffpfsc"
+        stdout_buffer: StringIO = StringIO()
+        stderr_buffer: StringIO = StringIO()
+        with patch.object(cli, "prompt_overwrite", return_value=True), redirect_stdout(stdout_buffer), redirect_stderr(
+            stderr_buffer
+        ):
+            rc: int = cli_mkpfs_main(
+                [
+                    "pack",
+                    "file",
+                    str(src),
+                    str(out),
+                    "--version",
+                    "PS5",
+                    "--inode-bits",
+                    "32",
+                    "--no-spool",
+                    "--temp-folder",
+                    str(tmp_path / "temp"),
+                    "--no-adjust-output-file-extension",
+                ]
+            )
+        self.assertEqual(rc, 0)
+        combined: str = stdout_buffer.getvalue() + stderr_buffer.getvalue()
+        self.assertIn("PFS Image Builder - Parameters", combined)
+        self.assertIn("Source path:", combined)
+        self.assertIn("Compressing 1 file", combined)

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -1568,3 +1568,59 @@ class TestCliPackFileNoSpool(CliTestCase):
         self.assertIn("PFS Image Builder - Parameters", combined)
         self.assertIn("Source path:", combined)
         self.assertIn("Compressing 1 file", combined)
+
+    def test_pack_file_no_spool_rejects_inode_bits_64(self) -> None:
+        """--no-spool only supports 32-bit inodes; --inode-bits 64 is rejected."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "x.exfat"
+        src.write_bytes(b"x" * 1000)
+        out: Path = tmp_path / "x.ffpfsc"
+        with self.assertRaises(BuildError):
+            cli_mkpfs_main(
+                [
+                    "pack",
+                    "file",
+                    str(src),
+                    str(out),
+                    "--no-spool",
+                    "--inode-bits",
+                    "64",
+                    "--no-adjust-output-file-extension",
+                ]
+            )
+
+    def test_pack_file_no_spool_rejects_auto_fit_block_size(self) -> None:
+        """--no-spool rejects auto-fit block size, which is meaningless for one file."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "x.exfat"
+        src.write_bytes(b"x" * 1000)
+        out: Path = tmp_path / "x.ffpfsc"
+        with self.assertRaises(BuildError):
+            cli_mkpfs_main(
+                [
+                    "pack",
+                    "file",
+                    str(src),
+                    str(out),
+                    "--no-spool",
+                    "--block-size",
+                    "auto-fit",
+                    "--no-adjust-output-file-extension",
+                ]
+            )
+
+    def test_pack_file_no_spool_dry_run_writes_nothing(self) -> None:
+        """--no-spool --dry-run reports layout without writing an image."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "PPSA.exfat"
+        src.write_bytes(b"DATA" * 20000 + b"\x00" * 60000)
+        out: Path = tmp_path / "PPSA.ffpfsc"
+        buffer: StringIO = StringIO()
+        with patch.object(cli, "prompt_overwrite", return_value=True), redirect_stdout(buffer), redirect_stderr(
+            StringIO()
+        ):
+            rc: int = cli_mkpfs_main(
+                ["pack", "file", str(src), str(out), "--no-spool", "--dry-run", "--no-adjust-output-file-extension"]
+            )
+        self.assertEqual(rc, 0)
+        self.assertFalse(out.exists())

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -1506,3 +1506,32 @@ class TestCliPackFileNoSpool(CliTestCase):
         parser: argparse.ArgumentParser = cli.cli_mkpfs_main_parsers()
         with self.assertRaises(SystemExit):
             parser.parse_args(["pack", "folder", "src", "out", "--no-spool"])
+
+    def test_pack_file_no_spool_with_verify_succeeds(self) -> None:
+        """`pack file --no-spool --verify` completes the post-create check without errors."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "PPSA.exfat"
+        src.write_bytes(b"GAMEDATA" * 20000 + b"\x00" * 200000)
+        out: Path = tmp_path / "PPSA.ffpfsc"
+        buffer: StringIO = StringIO()
+        with patch.object(cli, "prompt_overwrite", return_value=True), redirect_stdout(buffer), redirect_stderr(
+            StringIO()
+        ):
+            rc: int = cli_mkpfs_main(
+                [
+                    "pack",
+                    "file",
+                    str(src),
+                    str(out),
+                    "--version",
+                    "PS5",
+                    "--inode-bits",
+                    "32",
+                    "--no-spool",
+                    "--verify",
+                    "--temp-folder",
+                    str(tmp_path / "temp"),
+                    "--no-adjust-output-file-extension",
+                ]
+            )
+        self.assertEqual(rc, 0)

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -1624,3 +1624,35 @@ class TestCliPackFileNoSpool(CliTestCase):
             )
         self.assertEqual(rc, 0)
         self.assertFalse(out.exists())
+
+
+class TestCliTreeStructureOnly(CliTestCase):
+    """The tree command should render structure without decoding file payloads."""
+
+    def test_tree_does_not_decode_file_payloads(self) -> None:
+        """`mkpfs tree` builds the listing from metadata only, skipping payload hashing."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "blob.exfat"
+        src.write_bytes((b"GAMEDATA" * 4000) + b"\x00" * 200_000)
+        out: Path = tmp_path / "blob.ffpfsc"
+        cli.build_pfs_stream_single_file(
+            source_file=src,
+            output_path=out,
+            block_size=65536,
+            pfs_version=consts.PFS_VERSION_PS5,
+            case_insensitive=True,
+            zlib_level=9,
+            threshold_gain=0,
+            min_file_gain=0,
+            min_compress_size=0,
+            cpu_count=1,
+            compress=True,
+        )
+        buffer: StringIO = StringIO()
+        with patch.object(cli, "verify_file_payload_hashes") as mock_verify, redirect_stdout(buffer), redirect_stderr(
+            StringIO()
+        ):
+            rc: int = cli_mkpfs_main(["tree", str(out)])
+        self.assertEqual(rc, 0)
+        mock_verify.assert_not_called()
+        self.assertIn("blob.exfat", buffer.getvalue())

--- a/tests/mkpfs/test_pfs.py
+++ b/tests/mkpfs/test_pfs.py
@@ -2259,3 +2259,80 @@ class TestEncodePfscIntoHandle(PfsTestCase):
 
         assert (handle_size, handle_comp) == (spool_size, spool_comp)
         assert buf.getvalue()[4096 : 4096 + spool_size] == spool.read_bytes()[:spool_size]
+
+
+class TestStreamSingleFileBuilder(PfsTestCase):
+    """Tests for the spool-free single-file streaming builder."""
+
+    def test_stream_single_file_byte_identical_to_spool(self) -> None:
+        """Streaming builder output is byte-identical to the spool path for the same input."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "PPSA.exfat"
+        src.write_bytes((b"GAMEDATA" * 4096) + b"\x00" * 200_000)
+
+        with patch("mkpfs.pfs.time.time", return_value=1_700_000_000.0):
+            staging: Path = tmp_path / "stage"
+            staging.mkdir()
+            (staging / "PPSA.exfat").write_bytes(src.read_bytes())
+            out_spool: Path = tmp_path / "spool.ffpfsc"
+            build_pfs(
+                source_root=staging,
+                output_path=out_spool,
+                block_size=65536,
+                pfs_version=c.PFS_VERSION_PS5,
+                inode_bits=32,
+                case_insensitive=True,
+                signed=False,
+                compress=True,
+                threshold_gain=0,
+                cpu_count=1,
+                zlib_level=9,
+                dry_run=False,
+                verbose=False,
+                encrypted=False,
+                temp_folder=tmp_path / "t1",
+            )
+
+            out_stream: Path = tmp_path / "stream.ffpfsc"
+            pfs_mod.build_pfs_stream_single_file(
+                source_file=src,
+                output_path=out_stream,
+                block_size=65536,
+                pfs_version=c.PFS_VERSION_PS5,
+                case_insensitive=True,
+                zlib_level=9,
+                threshold_gain=0,
+                min_file_gain=0,
+                min_compress_size=0,
+                cpu_count=1,
+                compress=True,
+                encrypted=False,
+            )
+
+        assert out_stream.read_bytes() == out_spool.read_bytes()
+
+    def test_stream_single_file_round_trip(self) -> None:
+        """A streamed image extracts back to the original file bytes."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "blob.exfat"
+        payload: bytes = bytes(range(256)) * 3000 + b"\x00" * 100_000
+        src.write_bytes(payload)
+        out: Path = tmp_path / "blob.ffpfsc"
+        pfs_mod.build_pfs_stream_single_file(
+            source_file=src,
+            output_path=out,
+            block_size=65536,
+            pfs_version=c.PFS_VERSION_PS5,
+            case_insensitive=True,
+            zlib_level=9,
+            threshold_gain=0,
+            min_file_gain=0,
+            min_compress_size=0,
+            cpu_count=1,
+            compress=True,
+            encrypted=False,
+        )
+        dest: Path = tmp_path / "unpacked"
+        result = extract_pfs_image(image=out, output_path=dest)
+        assert not result.errors
+        assert (dest / "blob.exfat").read_bytes() == payload

--- a/tests/mkpfs/test_pfs.py
+++ b/tests/mkpfs/test_pfs.py
@@ -2391,3 +2391,136 @@ class TestStreamSingleFileBuilder(PfsTestCase):
         result = extract_pfs_image(image=out, output_path=dest, ekpfs=key)
         assert not result.errors
         assert (dest / "enc.exfat").read_bytes() == src.read_bytes()
+
+
+class TestStreamingDecode(PfsTestCase):
+    """Tests for flat-memory block-streaming decode of inode payloads."""
+
+    def _build_single(
+        self, tmp_path: Path, payload: bytes, *, encrypted: bool = False, key: bytes | None = None
+    ) -> Path:
+        """Build a single-file image and return its path."""
+        src: Path = tmp_path / "blob.exfat"
+        src.write_bytes(payload)
+        out: Path = tmp_path / "blob.ffpfsc"
+        pfs_mod.build_pfs_stream_single_file(
+            source_file=src,
+            output_path=out,
+            block_size=65536,
+            pfs_version=c.PFS_VERSION_PS5,
+            case_insensitive=True,
+            zlib_level=9,
+            threshold_gain=0,
+            min_file_gain=0,
+            min_compress_size=0,
+            cpu_count=1,
+            compress=True,
+            encrypted=encrypted,
+            ekpfs=key,
+        )
+        return out
+
+    def test_iter_blocks_matches_buffered_decode_compressed(self) -> None:
+        """Streaming a compressed multi-block payload equals the buffered decode and the source."""
+        tmp_path: Path = self.make_temp_path()
+        payload: bytes = (bytes(range(256)) * 4000) + b"\x00" * 200_000
+        out: Path = self._build_single(tmp_path, payload)
+        with out.open("rb") as fh:
+            header = pfs_mod.parse_image_header(fh)
+            inodes = pfs_mod.parse_image_inodes(fh, header)
+            file_inode = inodes[3]
+            self.assertTrue(file_inode.is_file)
+            self.assertTrue(file_inode.is_compressed)
+            buffered = pfs_mod.decode_inode_payload(
+                payload=pfs_mod.read_image_inode_payload(fh, header, file_inode), inode=file_inode
+            )
+            streamed = b"".join(pfs_mod.iter_inode_logical_blocks(fh, header, file_inode))
+        self.assertEqual(streamed, buffered)
+        self.assertEqual(streamed, payload)
+
+    def test_iter_blocks_matches_source_raw(self) -> None:
+        """Streaming an incompressible (raw) payload equals the source bytes."""
+        import os
+
+        tmp_path: Path = self.make_temp_path()
+        payload: bytes = os.urandom(200_000)
+        out: Path = self._build_single(tmp_path, payload)
+        with out.open("rb") as fh:
+            header = pfs_mod.parse_image_header(fh)
+            inodes = pfs_mod.parse_image_inodes(fh, header)
+            file_inode = inodes[3]
+            self.assertFalse(file_inode.is_compressed)
+            streamed = b"".join(pfs_mod.iter_inode_logical_blocks(fh, header, file_inode))
+        self.assertEqual(streamed, payload)
+
+    def test_iter_blocks_encrypted(self) -> None:
+        """Streaming decode works on an encrypted image with the EKPFS key."""
+        tmp_path: Path = self.make_temp_path()
+        key: bytes = b"\x22" * 32
+        payload: bytes = (b"ENCDATA!" * 6000) + b"\x00" * 90_000
+        out: Path = self._build_single(tmp_path, payload, encrypted=True, key=key)
+        with out.open("rb") as fh:
+            header = pfs_mod.parse_image_header(fh)
+            inodes = pfs_mod.parse_image_inodes(fh, header, ekpfs=key)
+            file_inode = inodes[3]
+            streamed = b"".join(pfs_mod.iter_inode_logical_blocks(fh, header, file_inode, ekpfs=key))
+        self.assertEqual(streamed, payload)
+
+
+class _RecordingProgress:
+    """Minimal Progress stand-in that records step() calls for assertions."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int, int]] = []
+
+    def step(self, phase: str, done: int, total: int, bytes_processed: int = 0) -> None:
+        self.calls.append((phase, done, total))
+
+    def status(self, message: str) -> None:
+        pass
+
+
+class TestVerifyProgress(PfsTestCase):
+    """Tests that the verify stage reports progress when a Progress sink is supplied."""
+
+    def _build_single(self, tmp_path: Path, payload: bytes) -> Path:
+        src: Path = tmp_path / "blob.exfat"
+        src.write_bytes(payload)
+        out: Path = tmp_path / "blob.ffpfsc"
+        pfs_mod.build_pfs_stream_single_file(
+            source_file=src,
+            output_path=out,
+            block_size=65536,
+            pfs_version=c.PFS_VERSION_PS5,
+            case_insensitive=True,
+            zlib_level=9,
+            threshold_gain=0,
+            min_file_gain=0,
+            min_compress_size=0,
+            cpu_count=1,
+            compress=True,
+            encrypted=False,
+        )
+        return out
+
+    def test_verify_file_payload_hashes_reports_progress(self) -> None:
+        """verify_file_payload_hashes drives a 'verify' progress phase to completion."""
+        tmp_path: Path = self.make_temp_path()
+        payload: bytes = (bytes(range(256)) * 4000) + b"\x00" * 200_000
+        out: Path = self._build_single(tmp_path, payload)
+        progress = _RecordingProgress()
+        with out.open("rb") as fh:
+            header = pfs_mod.parse_image_header(fh)
+            inodes = pfs_mod.parse_image_inodes(fh, header)
+            file_inodes = {"blob.exfat": 3}
+            errors: list[str] = []
+            checked, _crc, _manifest = pfs_mod.verify_file_payload_hashes(
+                fh, header, inodes, file_inodes, errors, progress=progress
+            )
+        self.assertEqual(checked, 1)
+        self.assertEqual(errors, [])
+        verify_calls = [ct for ct in progress.calls if ct[0] == "verify"]
+        self.assertTrue(verify_calls)
+        # Final verify update reaches 100% (done == total == logical size).
+        self.assertEqual(verify_calls[-1][1], verify_calls[-1][2])
+        self.assertEqual(verify_calls[-1][2], len(payload))

--- a/tests/mkpfs/test_pfs.py
+++ b/tests/mkpfs/test_pfs.py
@@ -2392,6 +2392,58 @@ class TestStreamSingleFileBuilder(PfsTestCase):
         assert not result.errors
         assert (dest / "enc.exfat").read_bytes() == src.read_bytes()
 
+    def test_stream_single_file_dry_run_writes_nothing(self) -> None:
+        """The streaming builder dry-run returns stats without creating the image."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "blob.exfat"
+        src.write_bytes((b"GAMEDATA" * 4000) + b"\x00" * 200_000)
+        out: Path = tmp_path / "blob.ffpfsc"
+        stats = pfs_mod.build_pfs_stream_single_file(
+            source_file=src,
+            output_path=out,
+            block_size=65536,
+            pfs_version=c.PFS_VERSION_PS5,
+            case_insensitive=True,
+            zlib_level=9,
+            threshold_gain=0,
+            min_file_gain=0,
+            min_compress_size=0,
+            cpu_count=1,
+            compress=True,
+            encrypted=False,
+            dry_run=True,
+        )
+        self.assertFalse(out.exists())
+        self.assertEqual(stats.total_files, 1)
+        self.assertEqual(stats.uncompressed_total_size, src.stat().st_size)
+
+    def test_stream_single_file_skips_executable_compression(self) -> None:
+        """Executable-like files are stored raw when skip_executable_compression is set."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "eboot.bin"
+        src.write_bytes((b"GAMEDATA" * 4000) + b"\x00" * 200_000)  # compressible
+        out: Path = tmp_path / "eboot.ffpfsc"
+        stats = pfs_mod.build_pfs_stream_single_file(
+            source_file=src,
+            output_path=out,
+            block_size=65536,
+            pfs_version=c.PFS_VERSION_PS5,
+            case_insensitive=True,
+            zlib_level=9,
+            threshold_gain=0,
+            min_file_gain=0,
+            min_compress_size=0,
+            cpu_count=1,
+            compress=True,
+            encrypted=False,
+            skip_executable_compression=True,
+        )
+        self.assertEqual(stats.compressed_files, 0)
+        dest: Path = tmp_path / "u"
+        result = extract_pfs_image(image=out, output_path=dest)
+        assert not result.errors
+        self.assertEqual((dest / "eboot.bin").read_bytes(), src.read_bytes())
+
 
 class TestStreamingDecode(PfsTestCase):
     """Tests for flat-memory block-streaming decode of inode payloads."""

--- a/tests/mkpfs/test_pfs.py
+++ b/tests/mkpfs/test_pfs.py
@@ -2222,3 +2222,40 @@ class TestSourceTreeScanning(PfsTestCase):
             (src / f"small_{idx}.bin").write_bytes(b"x" * 100)
 
         assert pfs_mod.choose_auto_fit_block_size(src) == 4096
+
+
+class TestEncodePfscIntoHandle(PfsTestCase):
+    """Tests for the reusable PFSC handle encoder shared with the spool path."""
+
+    def test_encode_pfsc_into_handle_matches_spool(self) -> None:
+        """Encoding into an open handle at a base offset matches the spool encoder bytes."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "src.bin"
+        src.write_bytes(b"AB" * 100_000 + b"\x00" * 50_000)
+
+        spool: Path = tmp_path / "out.pfsc"
+        spool_size, spool_comp, _spool_gain, _spool_hyp = pfs_mod._encode_pfsc_file_to_spool(
+            abs_path=src,
+            spool_path=spool,
+            threshold_gain=0,
+            min_file_gain=0,
+            zlib_level=9,
+            logical_block_size=c.PFSC_LOGICAL_BLOCK_SIZE,
+            block_worker_count=1,
+        )
+
+        buf: io.BytesIO = io.BytesIO()
+        buf.write(b"\x00" * 4096)
+        handle_size, handle_comp, _handle_gain, _handle_hyp = pfs_mod._encode_pfsc_into_handle(
+            out=buf,
+            base_offset=4096,
+            source_path=src,
+            threshold_gain=0,
+            min_file_gain=0,
+            zlib_level=9,
+            logical_block_size=c.PFSC_LOGICAL_BLOCK_SIZE,
+            block_worker_count=1,
+        )
+
+        assert (handle_size, handle_comp) == (spool_size, spool_comp)
+        assert buf.getvalue()[4096 : 4096 + spool_size] == spool.read_bytes()[:spool_size]

--- a/tests/mkpfs/test_pfs.py
+++ b/tests/mkpfs/test_pfs.py
@@ -2336,3 +2336,58 @@ class TestStreamSingleFileBuilder(PfsTestCase):
         result = extract_pfs_image(image=out, output_path=dest)
         assert not result.errors
         assert (dest / "blob.exfat").read_bytes() == payload
+
+    def test_stream_single_file_incompressible_stores_raw(self) -> None:
+        """Random (incompressible) input falls back to raw storage and still round-trips."""
+        import os
+
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "rand.bin"
+        src.write_bytes(os.urandom(300_000))
+        out: Path = tmp_path / "rand.ffpfsc"
+        stats = pfs_mod.build_pfs_stream_single_file(
+            source_file=src,
+            output_path=out,
+            block_size=65536,
+            pfs_version=c.PFS_VERSION_PS5,
+            case_insensitive=True,
+            zlib_level=9,
+            threshold_gain=0,
+            min_file_gain=0,
+            min_compress_size=0,
+            cpu_count=1,
+            compress=True,
+            encrypted=False,
+        )
+        assert stats.compressed_files == 0
+        dest: Path = tmp_path / "u"
+        result = extract_pfs_image(image=out, output_path=dest)
+        assert not result.errors
+        assert (dest / "rand.bin").read_bytes() == src.read_bytes()
+
+    def test_stream_single_file_encrypted_round_trip(self) -> None:
+        """An encrypted streamed image decrypts and extracts back to the source bytes."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "enc.exfat"
+        src.write_bytes(b"SECRET!!" * 5000 + b"\x00" * 80_000)
+        out: Path = tmp_path / "enc.ffpfsc"
+        key: bytes = b"\x11" * 32
+        pfs_mod.build_pfs_stream_single_file(
+            source_file=src,
+            output_path=out,
+            block_size=65536,
+            pfs_version=c.PFS_VERSION_PS5,
+            case_insensitive=True,
+            zlib_level=9,
+            threshold_gain=0,
+            min_file_gain=0,
+            min_compress_size=0,
+            cpu_count=1,
+            compress=True,
+            encrypted=True,
+            ekpfs=key,
+        )
+        dest: Path = tmp_path / "u"
+        result = extract_pfs_image(image=out, output_path=dest, ekpfs=key)
+        assert not result.errors
+        assert (dest / "enc.exfat").read_bytes() == src.read_bytes()


### PR DESCRIPTION
## Summary

Adds a `--no-spool` mode to `mkpfs pack file` that compresses a single source file directly into the output image with no temporary spool, and reworks the verify/unpack/tree read paths to stream block-by-block instead of buffering whole files in memory. Together these cut peak disk usage and make verifying, unpacking, or listing multi-GB images run in constant memory.

Targeted at the common workflow of packing a large `.exfat` (or nested PFS) image into a compressed `.ffpfsc` container.

## Motivation

- **Disk:** `pack file` spooled the compressed payload to a temp file, then copied it into the image, so peak disk was `source + spool + output` (~3x for a barely-compressible blob). For a raw `.exfat`, which always compresses somewhat, the spool was always written.
- **Memory:** `verify`, source comparison, `unpack`, and `tree` each decoded an entire logical file into a single in-RAM `bytearray` (and the source read another copy). On a simple 13.79 GB image this exhausted my 16GB of RAM and swapped almost 40GB, making these commands many times slower than the pack itself.

## What's in this PR

### 1. Spool-free single-file packing (`--no-spool`)

- New `build_pfs_stream_single_file` builder: writes provisional front metadata, streams the file's PFSC payload directly into its block region in a single compression pass, then back-patches the file inode and header total-block count and truncates.
- Output is **byte-identical** to the existing spool path for the same input (gated by a golden test).
- Shared encoder primitive `_encode_pfsc_into_handle` (the existing spool encoder is now a thin wrapper around it), plus extracted `_pack_pfs_header_block` and `_write_inode_table` helpers reused by both builders.

### 2. Flat-memory verify, unpack, and tree

- New `iter_inode_logical_blocks` generator yields a payload one logical block at a time (raw payloads stream in fixed chunks; signed payloads, bounded by the signed layout, keep the buffered path).
- `decode_pfsc_payload` refactored to share `_parse_pfsc_header` and `_decode_pfsc_block` with the generator.
- `verify_file_payload_hashes`, `validate_source_match`, and `extract_pfs_image` rewired to hash/compare/write incrementally. `Data CRC32` and `Manifest SHA256` are unchanged.
- `run_image_check` gains a `verify_payloads` flag; `tree` sets it to `False` so the listing is built from metadata and directory blocks only, skipping payload decode entirely while keeping all structural checks (inode layout, signatures, FPT maps, orphan inodes).
- Benefits every image, regardless of how it was packed.

### 3. Verify progress bar

- `verify` (payload hashing) and `compare` (source match) phases now show a progress bar with percentage, throughput, and ETA, reusing the pack renderer.
- Throttled to ~8 MB increments so it stays smooth on large images; shown only for interactive report runs.

### 4. CLI deduplication

- Extracted `PackBuildConfig` + `_resolve_pack_build_config` (one home for all shared param validation and option derivation), `_print_pack_parameters`, and `_run_post_pack_verify`. `_run_pack_build` and `_run_stream_pack_file` are now thin orchestrators that differ only at the builder call.
- Extracted `_single_file_build_stats`, shared by the streaming builder's dry-run and write paths.

### 5. `--no-spool` flag handling

- Honored: `--dry-run` (reports layout/stats, writes nothing), `--skip-executable-compression` (now applied by the streaming builder, matching the legacy path), plus the usual compression/version/encryption/verify flags.
- Rejected with clear errors: `--signed`, `--inode-bits 64` (the unsigned path is always 32-bit D32), and `--block-size auto-fit` (meaningless for one file).

## Disk and memory impact

- `pack file --no-spool` peak disk: `source + spool + output` -> `source + output` (no spool ever written; verify staging is a hardlink, not a copy).
- `verify` of a 1 GiB logical image: from whole-file RAM to **~31 MB peak RSS at ~890 MB/s**, flat regardless of file size.
- `tree` of a 512 MiB logical image: **~0.08s at ~28 MB peak RSS** (was a full payload decode), since it no longer touches file payloads.

## Scope and limitations

- `--no-spool` is single-file and unsigned only. Folder packing and signed images are unchanged and continue to use the existing spool path.
- Encrypted output is supported on the streaming path (encryption remains a post-pass over the finished local image).
- The verify/unpack streaming covers unsigned images; signed payloads still decode buffered (unchanged from before, and bounded by the signed size limit).

## Future direction

`--no-spool` is currently opt-in, but its rejection rules make it a natural default for `pack file`. A follow-up could make the streaming builder the default single-file path and **dynamically fall back to the legacy spool path only when an option the streaming builder cannot handle is supplied** (`--signed`, `--inode-bits 64`, or `--block-size auto-fit`). The common case (an unsigned `.exfat` or nested image) would get the low-disk, flat-memory path automatically, while signed/64-bit/auto-fit requests transparently route to the proven spool builder.

## Testing

- `uv run --frozen pytest`: 253 passing, `ruff` clean.
- Golden test: streamed `.ffpfsc` is byte-identical to the spool path.
- Round-trip tests: compressed, incompressible (raw fallback), and encrypted.
- Streaming-decode equivalence tests (compressed/raw/encrypted) vs the buffered decode.
- Verify progress, flag-rejection, dry-run, and tree structure-only tests.
- Real-image smoke tests for pack, verify (memory-measured), tree (memory-measured), and round-trip unpack.

## Notes

- Includes a small pre-existing `ruff` RUF052 fix (`_staging_base` rename) that was blocking `run-tests.sh` under the current ruff version.