### PR TITLE
fix: fail-fast on non-ASCII filenames before compression starts

### DIFF
--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -588,8 +588,15 @@ class Dirent:
 
         Returns:
             Bytes suitable for writing into a directory payload block.
+
+        Raises:
+            ValueError: If the name contains non-ASCII characters.
         """
-        name_bytes: bytes = self.name.encode("ascii", errors="strict")
+        if not self.name.isascii():
+            raise ValueError(
+                f"Filename {self.name!r} contains non-ASCII characters and cannot be stored in a PFS image"
+            )
+        name_bytes: bytes = self.name.encode("ascii")
         out: bytearray = bytearray()
         out += struct.pack("<Iiii", self.inode_number, self.type_code, self.name_length, self.ent_size)
         out += name_bytes
@@ -1985,6 +1992,22 @@ def scan_source_tree(root: Path, progress: Progress) -> tuple[dict[str, DirNode]
     progress.status("\nDiscovering files...")
     abs_files: list[Path] = [p for p in root.rglob("*") if p.is_file()]
     abs_files.sort(key=lambda p: p.relative_to(root).as_posix().lower())
+
+    # Validate filenames before compression work begins; non-ASCII names are unsupported.
+    non_ascii_paths: list[str] = []
+    for abs_path in abs_files:
+        rel_path: Path = abs_path.relative_to(root)
+        rel_str: str = rel_path.as_posix()
+        for part in rel_path.parts:
+            if not part.isascii():
+                non_ascii_paths.append(rel_str)
+                break
+    if non_ascii_paths:
+        offenders: str = "\n  ".join(non_ascii_paths)
+        raise BuildError(
+            f"Source tree contains {len(non_ascii_paths)} file(s) with non-ASCII names."
+            f" PFS images only support ASCII filenames:\n  {offenders}"
+        )
 
     dirs: dict[str, DirNode] = {"": DirNode(rel_dir="", name="uroot", parent_rel_dir=None)}
     files: dict[str, FileNode] = {}

--- a/tests/mkpfs/test_pfs.py
+++ b/tests/mkpfs/test_pfs.py
@@ -2049,6 +2049,13 @@ def assert_scan_source_tree(tmp_path: Path) -> None:
 class TestDirentSerialization(PfsTestCase):
     """Tests for dirent serialization behavior and encoded sizes."""
 
+    def test_non_ascii_filename_raises_value_error(self) -> None:
+        """Serializing a dirent with a non-ASCII name must raise ValueError."""
+        d: Dirent = Dirent(inode_number=1, type_code=2, name="café.bin")
+        with self.assertRaises(ValueError) as ctx:
+            d.to_bytes()
+        assert "non-ASCII" in str(ctx.exception)
+
     def test_file_dirent_matches_the_known_encoding_vector(self) -> None:
         """A file dirent should serialize to the expected known byte vector."""
         assert_dirent_to_bytes_known_vector()
@@ -2212,6 +2219,25 @@ class TestSourceTreeScanning(PfsTestCase):
     def test_scan_source_tree_returns_expected_directory_and_file_maps(self) -> None:
         """Scanning a small source tree should return the expected files, directories, and count."""
         assert_scan_source_tree(self.make_temp_path())
+
+    def test_scan_source_tree_raises_build_error_for_non_ascii_filenames(self) -> None:
+        """Scanning a tree with non-ASCII filenames must raise BuildError before compression."""
+        tmp_path: Path = self.make_temp_path()
+        root: Path = tmp_path / "src"
+        root.mkdir()
+        (root / "valid.bin").write_bytes(b"\x00" * 8)
+        (root / "münchen.bin").write_bytes(b"\x00" * 8)
+        sub: Path = root / "data"
+        sub.mkdir()
+        (sub / "résumé.txt").write_bytes(b"\x00" * 8)
+
+        progress: Progress = Progress(enabled=False)
+        with self.assertRaises(BuildError) as ctx:
+            scan_source_tree(root=root, progress=progress)
+        msg: str = str(ctx.exception)
+        assert "non-ASCII" in msg
+        assert "münchen.bin" in msg
+        assert "résumé.txt" in msg
 
     def test_auto_fit_block_size_prefers_small_blocks_for_small_files(self) -> None:
         """Auto-fit block-size selection should minimize estimated file-data footprint."""


### PR DESCRIPTION
 ## Problem

  When packing a folder containing files with non-ASCII filenames, mkpfs
  completed the full scan and compression stages before crashing with a
  `UnicodeEncodeError` during the write phase. All compression work was wasted.

  ## Fix

  - `scan_source_tree`: validates all path components for ASCII compatibility
    before compression begins, raising `BuildError` immediately with the full
    list of offending paths
  - `Dirent.to_bytes()`: adds a defensive `ValueError` guard for the same condition
  - Both checks use `str.isascii()` to avoid exception-for-control-flow

  ## Tests

  - `TestSourceTreeScanning.test_scan_source_tree_raises_build_error_for_non_ascii_filenames`:
    verifies fail-fast with multiple offending paths listed in the error message
  - `TestDirentSerialization.test_non_ascii_filename_raises_value_error`:
    verifies the defensive guard in `Dirent.to_bytes()`