### PR TITLE
Skip compression for executables or files that are too small

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,10 @@ mkpfs pack folder [-h] [--adjust-output-file-extension | --no-adjust-output-file
                   [--compression-level COMPRESSION_LEVEL]
                   [--max-compressed-ratio MAX_COMPRESSED_RATIO]
                   [--min-compress-size MIN_COMPRESS_SIZE]
+                  [--no-spool]
                   [--skip-executable-compression] [--signed] [--encrypted]
-                  [--ekpfs-key EKPFS_KEY] [--require-game-files] [--temp-folder TEMP_FOLDER] [--verbose]
-                  [--dry-run] [--verify] source_dir image_file
+                  [--ekpfs-key EKPFS_KEY] [--require-game-files] [--temp-folder TEMP_FOLDER] [--verbose] [--dry-run] [--verify]
+                  source_dir image_file
 ```
 
 Examples:
@@ -195,25 +196,26 @@ mkpfs pack folder ./input ./game.ffpfs --temp-folder ./tmp/mkpfs
 | `--no-adjust-output-file-extension` | Keep the requested output file name unchanged. |
 | `--compress` | Enable PFSC block compression. This is the default. |
 | `--no-compress` | Disable PFSC block compression. |
-| `--threshold-gain THRESHOLD_GAIN` | Minimum per-block gain percent required to keep PFSC-compressed blocks. Default: `0`. |
+| `--threshold-gain THRESHOLD_GAIN` | Minimum per-block gain percent required to keep PFSC-compressed blocks. Default: `5`. |
 | `--block-size BLOCK_SIZE` | PFS block size in bytes, `auto`, or `auto-fit`. Default: `auto`, which resolves to `65536`; `auto-fit` picks 4096..65536 by estimated file-data padding. |
 | `--version {PS4,PS5}` | PFS profile version. Default: `PS4`. |
 | `--inode-bits {32,64}` | Inode width mode bit. Default: `32`. (NOTE: 64 bits migth be unstable) |
 | `--case-sensitive` | Build a case-sensitive image. |
 | `--case-insensitive` | Set the case-insensitive mode bit. This is the default behavior. |
-| `--cpu-count CPU_COUNT` | Number of CPU cores to use for PFSC compression. `0` means auto `max(1, cpu_count())`, non-zero uses `max(1, user value)`. |
+| `--cpu-count CPU_COUNT` | Number of CPU cores to use for PFSC compression. `0` means auto `max(1, cpu_count() - 1)`, non-zero uses `max(1, user value)`. |
 | `--compression-level COMPRESSION_LEVEL` | Zlib compression level from `0` to `9`. Default: `7`. |
-| `--max-compressed-ratio MAX_COMPRESSED_RATIO` | Maximum PFSC size as percent of the raw file size. Use `95` to store files raw unless PFSC is 95% of raw size or smaller. Default: disabled. |
+| `--max-compressed-ratio MAX_COMPRESSED_RATIO` | Maximum PFSC size as percent of the raw file size. Use `95` to store files raw unless PFSC is 95% of raw size or smaller. Default: `95`. |
 | `--min-compress-size MIN_COMPRESS_SIZE` | Store files smaller than this many bytes raw without trying PFSC compression. When omitted (or set to `0`), MkPFS uses the resolved `--block-size` value, `65536` for `--block-size auto`, or the selected value for `--block-size auto-fit`. |
-| `--skip-executable-compression` | Store `eboot*.bin`, `*.prx`, and `*.sprx` files raw even when PFSC compression is enabled. Default: enabled. |
-| `--signed` | Build a signed PFS image using a zero EKPFS key and seed. |
-| `--encrypted` | Encrypt filesystem blocks with AES-XTS. |
-| `--ekpfs-key EKPFS_KEY` | Optional 64-hex EKPFS key. When omitted with `--encrypted`, MkPFS uses an all-zero key. |
-| `--require-game-files` | Require `sce_sys/param.json` and `eboot.bin` before packing. |
-| `--temp-folder TEMP_FOLDER` | Directory used for temporary pack artifacts, including staged single-file trees and PFSC spool files. Default: the system temp folder. |
-| `--verbose` | Print verbose per-file decisions during packing. |
-| `--dry-run` | Scan, layout, and report only. Do not write an image file. |
-| `--verify` | Run `mkpfs verify` automatically after a successful pack. |
+| `--no-spool`                                  | Keep preferring direct-to-image streaming for single-file packing. This is already the default when supported; unsupported option combinations transparently fall back to the legacy staged/spool path. |
+| `--skip-executable-compression`               | Skip compression in important executable files. Default: enabled. |
+| `--signed`                                    | Build a signed PFS image using a zero EKPFS key and seed. |
+| `--encrypted`                                 | Encrypt filesystem blocks with AES-XTS. |
+| `--ekpfs-key EKPFS_KEY`                       | Optional 64-hex EKPFS key. When omitted with `--encrypted`, MkPFS uses an all-zero key. |
+| `--require-game-files`                        | Require `sce_sys/param.json` and `eboot.bin` before packing. |
+| `--temp-folder TEMP_FOLDER`                   | Directory used for temporary pack artifacts, including the one-file staging tree and PFSC spool files. Default: the system temp folder. |
+| `--verbose`                                   | Print verbose per-file decisions during packing. |
+| `--dry-run`                                   | Scan, layout, and report only. Do not write an image file. |
+| `--verify`                                    | Run `mkpfs verify` automatically after a successful pack. |
 
 Notes:
 
@@ -254,7 +256,7 @@ mkpfs pack file ./payload.exfat ./payload.ffpfsc --temp-folder ./tmp/mkpfs
 | `--no-adjust-output-file-extension`           | Keep the requested output file name unchanged.                                                                                                                                                          |
 | `--compress`                                  | Enable PFSC block compression. This is the default.                                                                                                                                                     |
 | `--no-compress`                               | Disable PFSC block compression.                                                                                                                                                                         |
-| `--threshold-gain THRESHOLD_GAIN`             | Minimum per-block gain percent required to keep PFSC-compressed blocks. Default: `0`.                                                                                                                   |
+| `--threshold-gain THRESHOLD_GAIN`             | Minimum per-block gain percent required to keep PFSC-compressed blocks. Default: `5`.                                                                                                                   |
 | `--block-size BLOCK_SIZE`                     | PFS block size in bytes, `auto`, or `auto-fit`. Default: `auto`, which resolves to `65536`; `auto-fit` picks 4096..65536 by estimated file-data padding.                                                |
 | `--version {PS4,PS5}`                         | PFS profile version. Default: `PS4`.                                                                                                                                                                    |
 | `--inode-bits {32,64}`                        | Inode width mode bit. Default: `32`.                                                                                                                                                                    |
@@ -262,10 +264,10 @@ mkpfs pack file ./payload.exfat ./payload.ffpfsc --temp-folder ./tmp/mkpfs
 | `--case-insensitive`                          | Set the case-insensitive mode bit. This is the default behavior.                                                                                                                                        |
 | `--cpu-count CPU_COUNT`                       | Number of CPU cores to use for PFSC compression. `0` means auto `max(1, cpu_count() - 1)`, non-zero uses `max(1, user value)`.                                                                          |
 | `--compression-level COMPRESSION_LEVEL`       | Zlib compression level from `0` to `9`. Default: `7`.                                                                                                                                                   |
-| `--max-compressed-ratio MAX_COMPRESSED_RATIO` | Maximum PFSC size as percent of the raw file size. Use `95` to store files raw unless PFSC is 95% of raw size or smaller. Default: disabled.                                                            |
+| `--max-compressed-ratio MAX_COMPRESSED_RATIO` | Maximum PFSC size as percent of the raw file size. Use `95` to store files raw unless PFSC is 95% of raw size or smaller. Default: `95`.                                                                 |
 | `--min-compress-size MIN_COMPRESS_SIZE`       | Store files smaller than this many bytes raw without trying PFSC compression. When omitted (or set to `0`), MkPFS uses the resolved `--block-size` value, `65536` for `--block-size auto`, or the selected value for `--block-size auto-fit`.                                              |
 | `--no-spool`                                  | Keep preferring direct-to-image streaming for single-file packing. This is already the default when supported; unsupported option combinations transparently fall back to the legacy staged/spool path. |
-| `--skip-executable-compression`               | Store `eboot*.bin`, `*.prx`, and `*.sprx` files raw even when PFSC compression is enabled. Default: enabled.                                                                                            |
+| `--skip-executable-compression`               | Skip compression in important executable files. Default: enabled.                                                                                            |
 | `--signed`                                    | Build a signed PFS image using a zero EKPFS key and seed.                                                                                                                                               |
 | `--encrypted`                                 | Encrypt filesystem blocks with AES-XTS.                                                                                                                                                                 |
 | `--ekpfs-key EKPFS_KEY`                       | Optional 64-hex EKPFS key. When omitted with `--encrypted`, MkPFS uses an all-zero key.                                                                                                                 |

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -626,8 +626,8 @@ def cli_mkpfs_add_create_args(
     parser.add_argument(
         "--threshold-gain",
         type=int,
-        default=0,
-        help="Minimum per-block gain percent to keep PFSC-compressed blocks (default: 0)",
+        default=5,
+        help="Minimum per-block gain percent to keep PFSC-compressed blocks (default: 5)",
     )
     parser.add_argument(
         "--block-size",
@@ -665,8 +665,8 @@ def cli_mkpfs_add_create_args(
     parser.add_argument(
         "--max-compressed-ratio",
         type=int,
-        default=None,
-        help="Maximum PFSC size as percent of the raw file size (0-100)",
+        default=95,
+        help="Maximum PFSC size as percent of the raw file size (0-100, default: 95)",
     )
     parser.add_argument(
         "--min-compress-size",
@@ -681,7 +681,7 @@ def cli_mkpfs_add_create_args(
         "--skip-executable-compression",
         action="store_true",
         default=True,
-        help="Store eboot*.bin, *.prx, and *.sprx files raw even when PFSC compression is enabled",
+        help="Skip compression in important executable files",
     )
     parser.add_argument("--signed", action="store_true", help="Build a signed PFS image using zero EKPFS/seed")
     parser.add_argument("--encrypted", action="store_true", help="Encrypt filesystem blocks with AES-XTS")

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -723,13 +723,36 @@ class FileNode:
     inode: Inode | None = None
 
 
-def should_skip_executable_compression(file_name: str) -> bool:
-    """Return True for executable payloads that should stay raw when requested."""
+def should_skip_executable_compression(file_name: str, file_path: str) -> bool:
+    """Return True for executable-like payloads that should remain uncompressed.
+
+    This function checks both the plain file name and the file's relative path
+    inside the image. Some platform-specific markers (for example, "sce_module"
+    or "sce_sys") may appear in directory components rather than the base name,
+    so callers should pass the relative path when available.
+
+    Args:
+        file_name: Base file name (for example, "eboot.bin").
+        file_path: Relative path of the file inside the image (for example,
+            "sce_module/somefile.prx" or "sce_sys/param.json").
+
+    Returns:
+        True when the file should be kept raw (not PFSC-compressed), False
+        otherwise.
+    """
     lower_name: str = file_name.lower()
+    lower_path: str = file_path.lower()
     return (
         (lower_name.startswith("eboot") and lower_name.endswith(".bin"))
+        or (lower_name.startswith("param") and lower_name.endswith(".sfx"))
         or lower_name.endswith(".prx")
         or lower_name.endswith(".sprx")
+        or lower_name.endswith(".json")
+        or lower_name.endswith(".txt")
+        or lower_name.endswith(".png")
+        or lower_name.endswith("keystone")
+        or ("sce_module" in lower_path)
+        or ("sce_sys" in lower_path)
     )
 
 
@@ -2515,7 +2538,7 @@ def build_pfs(
     if compress and skip_executable_compression:
         compression_file_nodes = []
         for f in file_nodes_sorted:
-            if should_skip_executable_compression(f.name):
+            if should_skip_executable_compression(file_name=f.name, file_path=f.rel_path):
                 store_file_node_raw(f)
             else:
                 compression_file_nodes.append(f)
@@ -3282,7 +3305,10 @@ def build_pfs_stream_single_file(
         compress
         and raw_size > 0
         and raw_size >= min_compress_size
-        and not (skip_executable_compression and should_skip_executable_compression(source_file.name))
+        and not (
+            skip_executable_compression
+            and should_skip_executable_compression(file_name=source_file.name, file_path=source_file.name)
+        )
     )
     block_workers: int = resolve_block_compression_worker_count(
         requested_cpu_count=resolve_compression_worker_count(requested_cpu_count=cpu_count),

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -235,8 +235,8 @@ class TestCliArgumentHelpers(CliTestCase):
         )
         self.assertEqual(compression_action.default, 7)
 
-    def test_pack_parser_uses_zero_as_default_threshold_gain(self) -> None:
-        """The pack parser should expose 0 as the default threshold gain."""
+    def test_pack_parser_uses_five_as_default_threshold_gain(self) -> None:
+        """The pack parser should expose 5 as the default threshold gain."""
         parser: argparse.ArgumentParser = cli.cli_mkpfs_main_parsers()
         pack_parser: argparse.ArgumentParser = next(
             action.choices["pack"] for action in parser._actions if isinstance(action, argparse._SubParsersAction)
@@ -248,7 +248,7 @@ class TestCliArgumentHelpers(CliTestCase):
         threshold_action: argparse.Action = next(
             action for action in folder_parser._actions if getattr(action, "dest", "") == "threshold_gain"
         )
-        self.assertEqual(threshold_action.default, 0)
+        self.assertEqual(threshold_action.default, 5)
 
     def test_pack_parser_uses_thirty_two_as_default_inode_bits(self) -> None:
         """The pack parser should expose 32 as the default inode width."""
@@ -301,7 +301,7 @@ class TestCliArgumentHelpers(CliTestCase):
         )
         self.assertTrue(skip_action.default)
         self.assertIsNotNone(skip_action.help)
-        self.assertIn("eboot*.bin", skip_action.help or "")
+        self.assertIn("Skip compression", skip_action.help or "")
 
     def test_pack_parser_exposes_whole_file_compression_threshold(self) -> None:
         """The pack parser should expose the whole-file compression threshold."""
@@ -319,7 +319,7 @@ class TestCliArgumentHelpers(CliTestCase):
         min_size_action: argparse.Action = next(
             action for action in folder_parser._actions if getattr(action, "dest", "") == "min_compress_size"
         )
-        self.assertIsNone(max_ratio_action.default)
+        self.assertEqual(max_ratio_action.default, 95)
         self.assertEqual(min_size_action.default, 0)
 
     def test_pack_parser_cpu_count_help_mentions_auto_and_user_normalization(self) -> None:

--- a/tests/mkpfs/test_pfs.py
+++ b/tests/mkpfs/test_pfs.py
@@ -448,15 +448,36 @@ class TestEncryptedImageRoundTrip(PfsTestCase):
         eboot_path: Path = src / "eboot_patch.bin"
         prx_path: Path = src / "modules" / "libsample.prx"
         sprx_path: Path = src / "modules" / "libsample.sprx"
+        param_path: Path = src / "param_patch.sfx"
+        json_path: Path = src / "config.json"
+        txt_path: Path = src / "notes.txt"
+        png_path: Path = src / "image.png"
+        keystone_path: Path = src / "module.keystone"
+        sce_module_path: Path = src / "my_sce_module.bin"
+        sce_sys_name_path: Path = src / "contains_sce_sys.bin"
         normal_path: Path = src / "data" / "large.bin"
         prx_path.parent.mkdir(parents=True)
         eboot_payload: bytes = b"E" * 200000
         prx_payload: bytes = b"P" * 200000
         sprx_payload: bytes = b"X" * 200000
         normal_payload: bytes = b"N" * 200000
+        param_payload: bytes = b"A" * 200000
+        json_payload: bytes = b"J" * 200000
+        txt_payload: bytes = b"T" * 200000
+        png_payload: bytes = b"I" * 200000
+        keystone_payload: bytes = b"K" * 200000
+        sce_module_payload: bytes = b"M" * 200000
+        sce_sys_name_payload: bytes = b"S" * 200000
         eboot_path.write_bytes(eboot_payload)
         prx_path.write_bytes(prx_payload)
         sprx_path.write_bytes(sprx_payload)
+        param_path.write_bytes(param_payload)
+        json_path.write_bytes(json_payload)
+        txt_path.write_bytes(txt_payload)
+        png_path.write_bytes(png_payload)
+        keystone_path.write_bytes(keystone_payload)
+        sce_module_path.write_bytes(sce_module_payload)
+        sce_sys_name_path.write_bytes(sce_sys_name_payload)
         normal_path.write_bytes(normal_payload)
         out: Path = tmp_path / "skip-executables.ffpfs"
         build_pfs(
@@ -485,15 +506,36 @@ class TestEncryptedImageRoundTrip(PfsTestCase):
             eboot_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["eboot_patch.bin"]]
             prx_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["modules/libsample.prx"]]
             sprx_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["modules/libsample.sprx"]]
+            param_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["param_patch.sfx"]]
+            json_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["config.json"]]
+            txt_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["notes.txt"]]
+            png_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["image.png"]]
+            keystone_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["module.keystone"]]
+            sce_module_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["my_sce_module.bin"]]
+            sce_sys_name_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["contains_sce_sys.bin"]]
             normal_inode: pfs_mod.ParsedInode = inspection.inodes[inspection.file_inodes["data/large.bin"]]
 
             assert not eboot_inode.is_compressed
             assert not prx_inode.is_compressed
             assert not sprx_inode.is_compressed
+            assert not param_inode.is_compressed
+            assert not json_inode.is_compressed
+            assert not txt_inode.is_compressed
+            assert not png_inode.is_compressed
+            assert not keystone_inode.is_compressed
+            assert not sce_module_inode.is_compressed
+            assert not sce_sys_name_inode.is_compressed
             assert normal_inode.is_compressed
             assert pfs_mod.read_image_inode_payload(fh, header, eboot_inode) == eboot_payload
             assert pfs_mod.read_image_inode_payload(fh, header, prx_inode) == prx_payload
             assert pfs_mod.read_image_inode_payload(fh, header, sprx_inode) == sprx_payload
+            assert pfs_mod.read_image_inode_payload(fh, header, param_inode) == param_payload
+            assert pfs_mod.read_image_inode_payload(fh, header, json_inode) == json_payload
+            assert pfs_mod.read_image_inode_payload(fh, header, txt_inode) == txt_payload
+            assert pfs_mod.read_image_inode_payload(fh, header, png_inode) == png_payload
+            assert pfs_mod.read_image_inode_payload(fh, header, keystone_inode) == keystone_payload
+            assert pfs_mod.read_image_inode_payload(fh, header, sce_module_inode) == sce_module_payload
+            assert pfs_mod.read_image_inode_payload(fh, header, sce_sys_name_inode) == sce_sys_name_payload
             assert pfs_mod.read_image_inode_payload(fh, header, normal_inode)[:4] == b"PFSC"
 
     def test_min_file_gain_keeps_low_gain_files_raw(self) -> None:


### PR DESCRIPTION
## What changed
- expand executable-skip compression heuristics to also keep common low-value files raw (`.json`, `.txt`, `.png`, `.keystone`, `param*.sfx`, and `sce_module`/`sce_sys` path matches)
- update `should_skip_executable_compression` to evaluate both file name and relative path
- set CLI defaults to favor practical compression outcomes:
  - `--threshold-gain` default: `5`
  - `--max-compressed-ratio` default: `95`
- align CLI help text and README command reference with the new defaults and skip-compression wording
- add/adjust tests covering parser defaults and skip-compression behavior

## Why
This makes compression behavior safer and more efficient by default: it avoids PFSC on important files, very small or metadata-heavy files, and files that usually do not benefit from compression.

## Validation
- `uv run --frozen pytest tests/mkpfs/test_pfs.py tests/mkpfs/test_cli.py`