### PR TITLE
fix: preflight PFSC temp spool space checks

### DIFF
--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -31,6 +31,7 @@ from .pfs import (
     choose_auto_fit_block_size,
     compose_pfs_mode_with_sign,
     estimate_file_data_footprint,
+    estimate_pfsc_spool_size,
     extract_pfs_image,
     human_readable_size,
     inspect_pfs_image,
@@ -359,6 +360,36 @@ def get_destination_space_error_message(*, source_root: Path, output_path: Path)
     return (
         "ERROR: The destination file is on a disk that does not have enough space "
         f"({required_size_gb:.1f} GB) to perform the operation.\n"
+        "Operation cancelled."
+    )
+
+
+def get_temp_space_error_message(*, source_root: Path, temp_folder: Path) -> str | None:
+    """Build an insufficient-temp-space error for PFSC spool preflight.
+
+    Args:
+        source_root: Source directory whose raw file bytes may be spooled during
+            PFSC compression.
+        temp_folder: Temporary directory used for PFSC spool files.
+
+    Returns:
+        Error text when free temp space is insufficient, otherwise ``None``.
+    """
+    required_spool_size_bytes: int = 0
+    candidate_path: Path
+    for candidate_path in source_root.rglob("*"):
+        if candidate_path.is_file():
+            raw_size: int = candidate_path.stat().st_size
+            required_spool_size_bytes += estimate_pfsc_spool_size(raw_size=raw_size)
+    free_space_bytes: int = shutil.disk_usage(path=temp_folder).free
+    if free_space_bytes >= required_spool_size_bytes:
+        return None
+    required_size_gb: float = required_spool_size_bytes / float(1024**3)
+    free_size_gb: float = free_space_bytes / float(1024**3)
+    return (
+        "ERROR: The temp folder does not have enough free space for PFSC compression "
+        f"spool files (requires up to {required_size_gb:.1f} GB, has {free_size_gb:.1f} GB).\n"
+        "Use --temp-folder on a filesystem with more free space or free space in the current temp folder.\n"
         "Operation cancelled."
     )
 
@@ -985,6 +1016,14 @@ def _run_pack_build(
         if destination_space_error is not None:
             error(destination_space_error)
             return 1
+        if config.compress:
+            temp_space_error: str | None = get_temp_space_error_message(
+                source_root=build_source_root,
+                temp_folder=temp_folder,
+            )
+            if temp_space_error is not None:
+                error(temp_space_error)
+                return 1
 
     if not args.dry_run:
         cleanup_pack_temp_artifacts(output_path=output_path, temp_folder=temp_folder)

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -867,6 +867,32 @@ def _pfsc_header_size(*, block_count: int, logical_block_size: int) -> int:
     return consts.PFSC_INITIAL_DATA_OFFSET + (extra_blocks * logical_block_size)
 
 
+def estimate_pfsc_spool_size(*, raw_size: int, logical_block_size: int = consts.PFSC_LOGICAL_BLOCK_SIZE) -> int:
+    """Estimate the maximum transient spool size for PFSC encoding.
+
+    Args:
+        raw_size: Logical source file size in bytes.
+        logical_block_size: PFSC logical block size used for compression.
+
+    Returns:
+        Maximum temporary bytes a streaming PFSC spool may occupy before the
+        encoder decides whether to keep or discard the compressed payload.
+
+    Raises:
+        ValueError: If ``raw_size`` is negative or ``logical_block_size`` is not
+            positive.
+    """
+    if raw_size < 0:
+        raise ValueError(f"raw_size must be non-negative, got {raw_size}")
+    if logical_block_size <= 0:
+        raise ValueError(f"logical_block_size must be positive, got {logical_block_size}")
+    if raw_size == 0:
+        return 0
+    block_count: int = ceil_div(raw_size, logical_block_size)
+    padded_payload_size: int = block_count * logical_block_size
+    return _pfsc_header_size(block_count=block_count, logical_block_size=logical_block_size) + padded_payload_size
+
+
 def _should_store_pfsc_block_compressed(
     *,
     compressed_block_size: int,

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -986,6 +986,42 @@ class TestCliCreateRun(CliTestCase):
         )
         self.assertIn("Operation cancelled.", stderr_buffer.getvalue())
 
+    def test_create_run_returns_error_when_temp_disk_is_too_small(self) -> None:
+        """Create run should fail early when PFSC temp free space is below raw source size."""
+        tmp_path: Path = self.make_temp_path()
+        source_path: Path = self.make_valid_source(tmp_path)
+        args: SimpleNamespace = self.make_create_args(
+            source_path=source_path,
+            image_path=tmp_path / "out.ffpfs",
+            dry_run=False,
+            verify=False,
+        )
+        stderr_buffer: StringIO = StringIO()
+        with patch.object(cli, "validate_input", return_value=("TITLE", [])), patch.object(
+            cli,
+            "cleanup_pack_temp_artifacts",
+            side_effect=AssertionError("cleanup should not run"),
+        ), patch.object(
+            cli,
+            "prompt_overwrite",
+            side_effect=AssertionError("prompt should not run"),
+        ), patch.object(
+            cli,
+            "build_pfs",
+            side_effect=AssertionError("build should not run"),
+        ), patch.object(
+            cli.shutil,
+            "disk_usage",
+            side_effect=[
+                SimpleNamespace(total=100, used=1, free=100),
+                SimpleNamespace(total=10, used=9, free=1),
+            ],
+        ), redirect_stderr(stderr_buffer):
+            self.assertEqual(cli.cli_mkpfs_create_run(args), 1)
+        self.assertIn("ERROR: The temp folder does not have enough free space", stderr_buffer.getvalue())
+        self.assertIn("Use --temp-folder", stderr_buffer.getvalue())
+        self.assertIn("Operation cancelled.", stderr_buffer.getvalue())
+
     def test_create_run_runs_post_verify_and_returns_error_when_check_fails(self) -> None:
         """Create run should perform post-verify and return a failure code when verification reports errors."""
         tmp_path: Path = self.make_temp_path()


### PR DESCRIPTION
PFSC compression can transiently write large spool files before deciding whether to keep a compressed payload. The output destination free-space check does not protect the temp filesystem, so a large pack can fill the temp folder after work has already started.

This is especially dangerous when the default temp root is backed by tmpfs, because spool bytes consume memory instead of disk space and can make the machine unresponsive. Latest main already lets callers choose --temp-folder, but it still did not fail early when that temp folder was too small.

Estimate the worst-case PFSC spool footprint from the source tree, compare it with free space in the resolved temp folder, and cancel before cleanup, prompting, or build work begins. The estimate includes PFSC header and block padding overhead so it is conservative for the streaming spool format.