### PR TITLE
fix: add structure-only post-pack verification

### DIFF
--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -893,9 +893,9 @@ def _run_post_pack_verify(
         ``1`` when the check reports errors, otherwise ``0``.
     """
     if structure_only:
-        info("Running structural post-create check...")
+        info("Running structural post-pack check...")
     else:
-        info("Running full post-create check with payload hashing...")
+        info("Running full post-pack check with payload hashing...")
     errors, warnings, _tree, _uroot = run_image_check(
         output_path,
         source,

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -435,6 +435,7 @@ def run_image_check(
     new_crypt: bool = False,
     require_game_files: bool = False,
     verify_payloads: bool = True,
+    compare_source_payloads: bool = True,
 ) -> tuple[list[str], list[str], dict[int, list[ParsedDirent]], int]:
     errors: list[str] = []
     warnings: list[str] = []
@@ -534,6 +535,7 @@ def run_image_check(
                     ekpfs=ekpfs,
                     new_crypt=new_crypt,
                     progress=progress,
+                    compare_payloads=compare_source_payloads,
                 )
 
             compressed_count = sum(1 for i in file_inodes.values() if inodes[i].is_compressed)
@@ -695,6 +697,11 @@ def cli_mkpfs_add_create_args(
     parser.add_argument("--verbose", action="store_true", help="Verbose per-file decisions")
     parser.add_argument("--dry-run", action="store_true", help="Scan/layout/report only; do not write image")
     parser.add_argument("--verify", action="store_true", help="Run 'verify' after a successful pack")
+    parser.add_argument(
+        "--structure-only",
+        action="store_true",
+        help="When used with --verify, skip payload hashing and compare only image structure",
+    )
 
 
 def _resolve_pack_temp_folder(args: argparse.Namespace) -> Path:
@@ -793,7 +800,6 @@ def _resolve_pack_build_config(args: argparse.Namespace, *, block_size: int) -> 
         raise BuildError("--max-compressed-ratio must be within 0..100")
     if args.min_compress_size < 0:
         raise BuildError("--min-compress-size must be non-negative")
-
     min_compress_size: int = args.min_compress_size if args.min_compress_size > 0 else block_size
 
     encrypted: bool = bool(getattr(args, "encrypted", False))
@@ -871,6 +877,7 @@ def _run_post_pack_verify(
     ekpfs_key: bytes,
     new_crypt: bool,
     require_game_files: bool = False,
+    structure_only: bool = False,
 ) -> int:
     """Run the post-pack image check and report warnings and errors.
 
@@ -880,11 +887,15 @@ def _run_post_pack_verify(
         ekpfs_key: EKPFS key material for encrypted images.
         new_crypt: Whether to use the alternate newCrypt derivation.
         require_game_files: Whether to enable the optional game-file checklist.
+        structure_only: Whether to skip payload bytes and compare structure only.
 
     Returns:
         ``1`` when the check reports errors, otherwise ``0``.
     """
-    info("Running post-create check...")
+    if structure_only:
+        info("Running structural post-create check...")
+    else:
+        info("Running full post-create check with payload hashing...")
     errors, warnings, _tree, _uroot = run_image_check(
         output_path,
         source,
@@ -892,6 +903,8 @@ def _run_post_pack_verify(
         ekpfs=ekpfs_key,
         new_crypt=new_crypt,
         require_game_files=require_game_files,
+        verify_payloads=not structure_only,
+        compare_source_payloads=not structure_only,
     )
     for w in warnings:
         warning(w)
@@ -937,6 +950,10 @@ def _run_pack_build(
 
     if output_changed:
         info(output_adjustment_message)
+
+    if bool(getattr(args, "structure_only", False)) and not bool(getattr(args, "verify", False)):
+        error("--structure-only requires --verify")
+        return 1
 
     # Resolve block size (folder path additionally supports auto-fit over the tree).
     block_size_arg: str = str(args.block_size).strip().lower() if isinstance(args.block_size, str) else ""
@@ -1026,6 +1043,7 @@ def _run_pack_build(
         ekpfs_key=config.ekpfs_key,
         new_crypt=config.new_crypt,
         require_game_files=require_game_files,
+        structure_only=bool(getattr(args, "structure_only", False)),
     )
 
 
@@ -1327,6 +1345,10 @@ def _run_verify_check(
             info("--expected-manifest-sha256 must be a 64-hex SHA256 digest")
             return 2
         expected_manifest_sha256 = digest
+    structure_only: bool = bool(getattr(args, "structure_only", False))
+    if structure_only and (expected_crc32 is not None or expected_manifest_sha256 is not None):
+        info("--structure-only cannot be combined with expected payload hash options")
+        return 2
     ekpfs_key: bytes = parse_ekpfs_key_hex(getattr(args, "ekpfs_key", None))
     new_crypt: bool = bool(getattr(args, "new_crypt", False))
 
@@ -1339,6 +1361,8 @@ def _run_verify_check(
         require_game_files=require_game_files,
         ekpfs=ekpfs_key,
         new_crypt=new_crypt,
+        verify_payloads=not structure_only,
+        compare_source_payloads=not structure_only,
     )
     for w in warnings:
         warning(w)
@@ -1564,6 +1588,11 @@ def cli_mkpfs_main_parsers() -> argparse.ArgumentParser:
     check_parser.add_argument(
         "--expect-manifest-sha256",
         help="Expected manifest SHA256 (64 hex chars), fails if different",
+    )
+    check_parser.add_argument(
+        "--structure-only",
+        action="store_true",
+        help="Validate metadata, tree, FPT, and optional source hierarchy without hashing payload bytes",
     )
     check_parser.add_argument("--ekpfs-key", help="Optional 64-hex EKPFS key for encrypted images")
     check_parser.add_argument("--new-crypt", action="store_true", help="Use alternate newCrypt EKPFS derivation")

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -4692,6 +4692,7 @@ def validate_source_match(
     ekpfs: bytes | None = None,
     new_crypt: bool = False,
     progress: Progress | None = None,
+    compare_payloads: bool = True,
 ) -> None:
     if not source.exists() or not source.is_dir():
         errors.append(f"source path does not exist or is not a directory: {source}")
@@ -4705,6 +4706,9 @@ def validate_source_match(
         errors.append(f"missing in image: {rel}")
     for rel in sorted(image_rel - source_rel):
         errors.append(f"extra in image: {rel}")
+
+    if not compare_payloads:
+        return
 
     common = sorted(source_rel & image_rel)
     # Report progress against the total logical bytes to compare, throttled by volume.

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -85,6 +85,7 @@ class CliTestCase(unittest.TestCase):
             verbose=False,
             dry_run=dry_run,
             verify=verify,
+            structure_only=False,
         )
 
     def make_pack_file_args(
@@ -114,6 +115,7 @@ class CliTestCase(unittest.TestCase):
             verbose=False,
             dry_run=dry_run,
             verify=verify,
+            structure_only=False,
         )
 
 
@@ -1007,8 +1009,60 @@ class TestCliCreateRun(CliTestCase):
             cli,
             "run_image_check",
             return_value=(["error"], ["warning"], {}, -1),
-        ):
+        ) as mocked_run_image_check:
             self.assertEqual(cli.cli_mkpfs_create_run(args), 1)
+        _pos_args, keyword_args = mocked_run_image_check.call_args
+        self.assertTrue(keyword_args["verify_payloads"])
+        self.assertTrue(keyword_args["compare_source_payloads"])
+
+    def test_create_run_structure_only_disables_payload_checks(self) -> None:
+        """Create run should skip payload and source bytes for structure-only verify."""
+        tmp_path: Path = self.make_temp_path()
+        source_path: Path = self.make_valid_source(tmp_path)
+        output_path: Path = tmp_path / "out.ffpfs"
+        args: SimpleNamespace = self.make_create_args(
+            source_path=source_path,
+            image_path=output_path,
+            dry_run=False,
+            verify=True,
+        )
+        args.structure_only = True
+        with patch.object(cli, "validate_input", return_value=("TITLE", [])), patch.object(
+            cli,
+            "prompt_overwrite",
+            return_value=True,
+        ), patch.object(
+            cli, "build_pfs", return_value=BuildStats(input_path=source_path, output_path=output_path)
+        ), patch.object(
+            cli,
+            "run_image_check",
+            return_value=([], [], {}, -1),
+        ) as mocked_run_image_check:
+            self.assertEqual(cli.cli_mkpfs_create_run(args), 0)
+        _pos_args, keyword_args = mocked_run_image_check.call_args
+        self.assertFalse(keyword_args["verify_payloads"])
+        self.assertFalse(keyword_args["compare_source_payloads"])
+
+    def test_create_run_rejects_structure_only_without_verify(self) -> None:
+        """Structure-only is only meaningful when post-pack verification runs."""
+        tmp_path: Path = self.make_temp_path()
+        source_path: Path = self.make_valid_source(tmp_path)
+        output_path: Path = tmp_path / "out.ffpfs"
+        args: SimpleNamespace = self.make_create_args(
+            source_path=source_path,
+            image_path=output_path,
+            dry_run=False,
+            verify=False,
+        )
+        args.structure_only = True
+        stderr_buffer: StringIO = StringIO()
+        with patch.object(cli, "validate_input", return_value=("TITLE", [])), patch.object(
+            cli,
+            "build_pfs",
+            side_effect=AssertionError("build should not run"),
+        ), redirect_stderr(stderr_buffer):
+            self.assertEqual(cli.cli_mkpfs_create_run(args), 1)
+        self.assertIn("--structure-only requires --verify", stderr_buffer.getvalue())
 
     def test_create_run_supports_signed_64_bit_inode_dry_run(self) -> None:
         """Create run should accept the signed 64-bit inode combination during a real dry run."""
@@ -1204,6 +1258,40 @@ class TestCliReadOnlyCommands(CliTestCase):
             self.assertEqual(cli.cli_mkpfs_check_run(args), 0)
         self.assertTrue(mocked_run.call_args.kwargs["require_game_files"])
 
+    def test_check_run_structure_only_disables_payload_checks(self) -> None:
+        """Verify structure-only should skip payload and source byte comparison."""
+        args: SimpleNamespace = SimpleNamespace(
+            image_file="img.ffpfs",
+            source_dir=None,
+            source_file=None,
+            expect_crc32=None,
+            expect_manifest_sha256=None,
+            structure_only=True,
+            require_game_files=False,
+            ekpfs_key=None,
+            new_crypt=False,
+        )
+        with patch.object(cli, "run_image_check", return_value=([], [], {}, -1)) as mocked_run_image_check:
+            self.assertEqual(cli.cli_mkpfs_check_run(args), 0)
+        _pos_args, keyword_args = mocked_run_image_check.call_args
+        self.assertFalse(keyword_args["verify_payloads"])
+        self.assertFalse(keyword_args["compare_source_payloads"])
+
+    def test_check_run_rejects_structure_only_with_expected_hashes(self) -> None:
+        """Verify structure-only should reject expected payload hash checks."""
+        args: SimpleNamespace = SimpleNamespace(
+            image_file="img.ffpfs",
+            source_dir=None,
+            source_file=None,
+            expect_crc32="0x1234",
+            expect_manifest_sha256=None,
+            structure_only=True,
+            ekpfs_key=None,
+            new_crypt=False,
+        )
+        with patch.object(cli, "run_image_check", side_effect=AssertionError("verify should not run")):
+            self.assertEqual(cli.cli_mkpfs_check_run(args), 2)
+
     def test_check_run_supports_source_file_by_staging_single_file_tree(self) -> None:
         """Verify should stage a single source file as root content without copying bytes."""
         tmp_path: Path = self.make_temp_path()
@@ -1221,8 +1309,11 @@ class TestCliReadOnlyCommands(CliTestCase):
             require_game_files: bool = False,
             ekpfs: bytes | None = None,
             new_crypt: bool = False,
+            verify_payloads: bool = True,
+            compare_source_payloads: bool = True,
         ) -> tuple[list[str], list[str], dict[int, list[ParsedDirent]], int]:
             del image, print_tree, expected_crc32, expected_manifest_sha256, emit_report, ekpfs, new_crypt
+            del verify_payloads, compare_source_payloads
             self.assertFalse(require_game_files)
             seen_source.append(source)
             assert source is not None

--- a/tests/mkpfs/test_pfs.py
+++ b/tests/mkpfs/test_pfs.py
@@ -650,6 +650,68 @@ class TestEncryptedImageRoundTrip(PfsTestCase):
         assert out.is_file()
         assert out.stat().st_size > 0
 
+    def test_validate_source_match_can_skip_payload_comparison(self) -> None:
+        """Source comparison should support hierarchy-only verification."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = make_app_with_nested_dirs(tmp_path / "src")
+        out: Path = tmp_path / "hierarchy-source-match.ffpfs"
+        build_pfs(
+            source_root=src,
+            output_path=out,
+            block_size=65536,
+            pfs_version=c.PFS_VERSION_PS5,
+            inode_bits=32,
+            case_insensitive=True,
+            signed=False,
+            compress=False,
+            threshold_gain=1,
+            cpu_count=1,
+            zlib_level=9,
+            dry_run=False,
+            verbose=False,
+            encrypted=False,
+        )
+
+        with out.open("rb") as fh:
+            header: pfs_mod.ParsedHeader = parse_image_header(fh)
+            inodes: list[pfs_mod.ParsedInode] = parse_image_inodes(fh, header)
+            errors: list[str] = []
+            uroot_inode: int
+            uroot_inode, _fpt_map, _collision_map, _special_inodes = pfs_mod.parse_superroot_and_indexes(
+                fh,
+                header,
+                inodes,
+                errors,
+            )
+            file_inodes: dict[str, int]
+            file_inodes, _dir_inodes, _tree = pfs_mod.build_tree_from_uroot(
+                fh,
+                header,
+                inodes,
+                uroot_inode,
+                errors,
+            )
+            with patch.object(
+                pfs_mod,
+                "read_image_inode_payload",
+                side_effect=AssertionError("hierarchy-only comparison should not read image payloads"),
+            ), patch.object(
+                Path,
+                "open",
+                side_effect=AssertionError("hierarchy-only comparison should not read source payloads"),
+            ):
+                pfs_mod.validate_source_match(
+                    fh,
+                    header,
+                    inodes,
+                    file_inodes,
+                    src,
+                    errors,
+                    compare_payloads=False,
+                )
+
+        assert errors == []
+
     def test_pfsc_encode_decode_round_trip(self) -> None:
         """PFSC payload encoding and decoding should preserve logical bytes."""
         raw: bytes = (b"A" * 65536) + (b"B" * 65536) + (b"C" * 1234)


### PR DESCRIPTION
pack --verify currently reuses the full image verification path, including payload hashing and source byte comparison. On very large images this can immediately reread and decode the full output after packing, which is expensive and can exhaust memory or make the system unstable depending on payload size and compression.

Preserve that existing --verify behavior for compatibility, and add an explicit --structure-only modifier for callers that want a lightweight post-pack check. The structural mode still validates the header, inode layout, signatures where applicable, tree traversal, FPT maps, and source hierarchy, but it skips payload hashing and source byte comparison.

Standalone mkpfs verify keeps payload verification by default and also supports --structure-only for the same lightweight mode. Source hierarchy comparison can now skip payload reads with compare_payloads False while retaining upstream's streaming comparison path for full verification.