### PR TITLE
fix: rebuild FPT after final inode numbering

### DIFF
--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -1913,6 +1913,41 @@ def make_fpt_and_collision_blob(
     return bytes(fpt), (bytes(collision_blob) if has_collision else None), has_collision
 
 
+def paths_have_fpt_collision(
+    dirs_sorted: list[DirNode],
+    files_sorted: list[FileNode],
+    case_insensitive: bool = True,
+) -> bool:
+    """Return whether the source paths require a collision resolver.
+
+    Args:
+        dirs_sorted: Directory nodes considered for flat path table entries.
+        files_sorted: File nodes considered for flat path table entries.
+        case_insensitive: Whether hashes should use case-insensitive path folding.
+
+    Returns:
+        ``True`` when two or more paths produce the same FPT hash, otherwise
+        ``False``.
+    """
+    seen_hashes: set[int] = set()
+    path_value: str
+    for directory_node in dirs_sorted:
+        if directory_node.rel_dir == "":
+            continue
+        path_value = dir_full_path_for_hash(directory_node)
+        path_hash: int = fpt_hash(path_value, case_insensitive=case_insensitive)
+        if path_hash in seen_hashes:
+            return True
+        seen_hashes.add(path_hash)
+    for file_node in files_sorted:
+        path_value = file_full_path_for_hash(file_node)
+        path_hash = fpt_hash(path_value, case_insensitive=case_insensitive)
+        if path_hash in seen_hashes:
+            return True
+        seen_hashes.add(path_hash)
+    return False
+
+
 def compute_file_storage(
     file_node: FileNode,
     compress: bool,
@@ -2797,12 +2832,12 @@ def build_pfs(
             child_file = files[child_rel_file]
             d.dirents.append(Dirent(child_file.inode.number, consts.DIRENT_TYPE_FILE, child_file.name))
 
-    fpt_blob, collision_blob, has_collision = make_fpt_and_collision_blob(
+    has_collision: bool = paths_have_fpt_collision(
         dir_nodes_sorted,
         file_nodes_sorted,
-        inode_by_path,
         case_insensitive=case_insensitive,
     )
+    collision_blob: bytes | None = None
 
     if has_collision:
         collision_inode = Inode(
@@ -2812,9 +2847,9 @@ def build_pfs(
             flags=consts.INODE_FLAG_INTERNAL
             | consts.INODE_FLAG_READONLY
             | (consts.INODE_FLAG_SIGNED_EXTRA if signed else 0),
-            size=len(collision_blob or b""),
-            size_compressed=len(collision_blob or b""),
-            blocks=max(1, ceil_div(len(collision_blob or b""), block_size)),
+            size=0,
+            size_compressed=0,
+            blocks=1,
             time_sec=now,
         )
         inodes = [super_root_inode, fpt_inode, collision_inode, uroot_inode] + [
@@ -2839,6 +2874,19 @@ def build_pfs(
             inode_by_path[f"dir:{d.rel_dir}"] = d.inode
         for f in file_nodes_sorted:
             inode_by_path[f"file:{f.rel_path}"] = f.inode
+
+    # Build FPT artifacts after any collision inode insertion and renumbering.
+    fpt_blob, collision_blob, has_collision = make_fpt_and_collision_blob(
+        dir_nodes_sorted,
+        file_nodes_sorted,
+        inode_by_path,
+        case_insensitive=case_insensitive,
+    )
+    if collision_inode is not None:
+        collision_blob_size: int = len(collision_blob or b"")
+        collision_inode.size = collision_blob_size
+        collision_inode.size_compressed = collision_blob_size
+        collision_inode.blocks = max(1, ceil_div(collision_blob_size, block_size))
 
     super_root_dirents: list[Dirent] = [Dirent(fpt_inode.number, consts.DIRENT_TYPE_FILE, "flat_path_table")]
     if has_collision and collision_inode is not None:

--- a/tests/mkpfs/test_pfs.py
+++ b/tests/mkpfs/test_pfs.py
@@ -628,8 +628,16 @@ class TestEncryptedImageRoundTrip(PfsTestCase):
         tmp_path: Path = self.make_temp_path()
         src: Path = make_app_with_nested_dirs(tmp_path / "src")
         out: Path = tmp_path / "collision-renumbering.ffpfs"
+        original_fpt_hash: Callable[[str, bool], int] = pfs_mod.fpt_hash
+        collision_paths: set[str] = {"/data/levels/level1.bin", "/data/levels/level2.bin"}
 
-        with patch.object(pfs_mod, "fpt_hash", return_value=0x12345678):
+        def selective_collision_hash(path: str, case_insensitive: bool = True) -> int:
+            """Force one FPT collision while preserving other path hashes."""
+            if path in collision_paths:
+                return 0x12345678
+            return original_fpt_hash(path, case_insensitive=case_insensitive)
+
+        with patch.object(pfs_mod, "fpt_hash", side_effect=selective_collision_hash):
             build_pfs(
                 source_root=src,
                 output_path=out,
@@ -646,9 +654,60 @@ class TestEncryptedImageRoundTrip(PfsTestCase):
                 verbose=False,
                 encrypted=False,
             )
+            errors: list[str]
+            errors, _warnings, _tree, _uroot = run_image_check(
+                out,
+                src,
+                print_tree=False,
+                emit_report=False,
+            )
 
         assert out.is_file()
         assert out.stat().st_size > 0
+        assert errors == []
+
+    def test_build_pfs_handles_fpt_collision_inode_renumbering_without_compression(self) -> None:
+        """Forced FPT collisions should verify cleanly when compression is disabled."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = make_app_with_nested_dirs(tmp_path / "src")
+        out: Path = tmp_path / "collision-renumbering-raw.ffpfs"
+        original_fpt_hash: Callable[[str, bool], int] = pfs_mod.fpt_hash
+        collision_paths: set[str] = {"/data/levels/level1.bin", "/data/levels/level2.bin"}
+
+        def selective_collision_hash(path: str, case_insensitive: bool = True) -> int:
+            """Force one FPT collision while preserving other path hashes."""
+            if path in collision_paths:
+                return 0x12345678
+            return original_fpt_hash(path, case_insensitive=case_insensitive)
+
+        with patch.object(pfs_mod, "fpt_hash", side_effect=selective_collision_hash):
+            build_pfs(
+                source_root=src,
+                output_path=out,
+                block_size=65536,
+                pfs_version=c.PFS_VERSION_PS5,
+                inode_bits=32,
+                case_insensitive=True,
+                signed=False,
+                compress=False,
+                threshold_gain=1,
+                cpu_count=1,
+                zlib_level=9,
+                dry_run=False,
+                verbose=False,
+                encrypted=False,
+            )
+            errors: list[str]
+            errors, _warnings, _tree, _uroot = run_image_check(
+                out,
+                src,
+                print_tree=False,
+                emit_report=False,
+            )
+
+        assert out.is_file()
+        assert out.stat().st_size > 0
+        assert errors == []
 
     def test_pfsc_encode_decode_round_trip(self) -> None:
         """PFSC payload encoding and decoding should preserve logical bytes."""


### PR DESCRIPTION
The flat path table and collision resolver recorded inode numbers before collision_resolver was inserted. When an FPT collision existed, adding that internal inode shifted uroot and every later tree inode by one, but the already-built FPT and collision blobs still contained the old numbers. Verification then reported systematic FPT mismatches where the expected inode was actual + 1.

Build only the collision decision before insertion. After any collision inode insertion and non-special inode renumbering, materialize the FPT and collision blobs from the final inode map. Update the collision inode size and block count after the final collision blob is known.