### PR TITLE
[FEATURE] Make direct-to-image streaming the default for pack file (--use-spool to opt out)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ mkpfs pack folder [-h] [--adjust-output-file-extension | --no-adjust-output-file
                   [--compression-level COMPRESSION_LEVEL]
                   [--max-compressed-ratio MAX_COMPRESSED_RATIO]
                   [--min-compress-size MIN_COMPRESS_SIZE]
-                  [--no-spool]
                   [--skip-executable-compression] [--signed] [--encrypted]
                   [--ekpfs-key EKPFS_KEY] [--require-game-files] [--temp-folder TEMP_FOLDER] [--verbose] [--dry-run] [--verify]
                   source_dir image_file
@@ -206,7 +205,6 @@ mkpfs pack folder ./input ./game.ffpfs --temp-folder ./tmp/mkpfs
 | `--compression-level COMPRESSION_LEVEL` | Zlib compression level from `0` to `9`. Default: `7`. |
 | `--max-compressed-ratio MAX_COMPRESSED_RATIO` | Maximum PFSC size as percent of the raw file size. Use `95` to store files raw unless PFSC is 95% of raw size or smaller. Default: `95`. |
 | `--min-compress-size MIN_COMPRESS_SIZE` | Store files smaller than this many bytes raw without trying PFSC compression. When omitted (or set to `0`), MkPFS uses the resolved `--block-size` value, `65536` for `--block-size auto`, or the selected value for `--block-size auto-fit`. |
-| `--no-spool`                                  | Keep preferring direct-to-image streaming for single-file packing. This is already the default when supported; unsupported option combinations transparently fall back to the legacy staged/spool path. |
 | `--skip-executable-compression`               | Skip compression in important executable files. Default: enabled. |
 | `--signed`                                    | Build a signed PFS image using a zero EKPFS key and seed. |
 | `--encrypted`                                 | Encrypt filesystem blocks with AES-XTS. |
@@ -233,7 +231,7 @@ mkpfs pack file [-h] [--adjust-output-file-extension | --no-adjust-output-file-e
                 [--compression-level COMPRESSION_LEVEL]
                 [--max-compressed-ratio MAX_COMPRESSED_RATIO]
                 [--min-compress-size MIN_COMPRESS_SIZE]
-                [--no-spool]
+                [--use-spool]
                 [--skip-executable-compression] [--signed] [--encrypted]
                 [--ekpfs-key EKPFS_KEY] [--temp-folder TEMP_FOLDER] [--verbose] [--dry-run] [--verify]
                 source_file image_file
@@ -266,7 +264,7 @@ mkpfs pack file ./payload.exfat ./payload.ffpfsc --temp-folder ./tmp/mkpfs
 | `--compression-level COMPRESSION_LEVEL`       | Zlib compression level from `0` to `9`. Default: `7`.                                                                                                                                                   |
 | `--max-compressed-ratio MAX_COMPRESSED_RATIO` | Maximum PFSC size as percent of the raw file size. Use `95` to store files raw unless PFSC is 95% of raw size or smaller. Default: `95`.                                                                 |
 | `--min-compress-size MIN_COMPRESS_SIZE`       | Store files smaller than this many bytes raw without trying PFSC compression. When omitted (or set to `0`), MkPFS uses the resolved `--block-size` value, `65536` for `--block-size auto`, or the selected value for `--block-size auto-fit`.                                              |
-| `--no-spool`                                  | Keep preferring direct-to-image streaming for single-file packing. This is already the default when supported; unsupported option combinations transparently fall back to the legacy staged/spool path. |
+| `--use-spool`                                 | Force the legacy staged/spool builder instead of the default direct-to-image streaming. |
 | `--skip-executable-compression`               | Skip compression in important executable files. Default: enabled.                                                                                            |
 | `--signed`                                    | Build a signed PFS image using a zero EKPFS key and seed.                                                                                                                                               |
 | `--encrypted`                                 | Encrypt filesystem blocks with AES-XTS.                                                                                                                                                                 |
@@ -278,10 +276,11 @@ mkpfs pack file ./payload.exfat ./payload.ffpfsc --temp-folder ./tmp/mkpfs
 
 Notes:
 
-- `pack file` now uses the direct-to-image streaming builder by default for supported option combinations. It
-  automatically falls back to the legacy staged/spool path for `--signed`, `--inode-bits 64`, and
-  `--block-size auto-fit`.
-- Single-file fallback mode stages the file in a temporary one-file tree using links, so the source payload is not
+- `pack file` streams directly to the image by default, which keeps peak disk use to the source plus the output and
+  keeps memory flat. `--signed`, `--inode-bits 64`, and `--block-size auto-fit` automatically use the legacy
+  staged/spool path instead, with an on-screen notice explaining why.
+- Pass `--use-spool` to force the legacy staged/spool path even when streaming is available.
+- The fallback path stages the file in a temporary one-file tree using links, so the source payload is not
   duplicated on disk.
 - Use `--temp-folder` when you want fallback staged files and any legacy PFSC spool files to live somewhere other than
   the system temp directory.

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -742,21 +742,24 @@ def _resolve_pack_temp_folder(args: argparse.Namespace) -> Path:
     return resolve_temp_root(temp_folder=temp_folder)
 
 
-def _can_stream_pack_file(*, args: argparse.Namespace) -> bool:
-    """Return whether single-file packing can use the streaming builder.
+def _stream_fallback_reason(*, args: argparse.Namespace) -> str | None:
+    """Return why single-file streaming is unavailable, or None when supported.
 
     Args:
         args: Parsed CLI arguments for the single-file pack workflow.
 
     Returns:
-        True when the streaming builder supports the requested options.
+        A human-readable reason the streaming builder cannot be used, or ``None``
+        when the requested options are supported by streaming.
     """
+    if bool(getattr(args, "signed", False)):
+        return "signed images"
+    if int(getattr(args, "inode_bits", 32)) != 32:
+        return "64-bit inodes"
     block_size_arg: str = str(getattr(args, "block_size", "")).strip().lower()
-    return not (
-        bool(getattr(args, "signed", False))
-        or int(getattr(args, "inode_bits", 32)) != 32
-        or block_size_arg in {"auto-fit", "auto_small_files", "auto-small-files"}
-    )
+    if block_size_arg in {"auto-fit", "auto_small_files", "auto-small-files"}:
+        return "auto-fit block size"
+    return None
 
 
 @dataclass(frozen=True)
@@ -1183,12 +1186,8 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
     if output_changed:
         info("Single file streaming mode enabled, adjusting output file extension to .ffpfsc")
 
-    # Resolve block size (single-file path: auto or explicit, no auto-fit).
+    # Resolve block size (single-file path: auto or explicit; auto-fit routes to the spool path).
     block_size_arg: str = str(args.block_size).strip().lower() if isinstance(args.block_size, str) else ""
-    if block_size_arg in {"auto-fit", "auto_small_files", "auto-small-files"}:
-        raise BuildError(
-            "--block-size auto-fit is not supported for single-file packing; use 'auto' or an explicit size"
-        )
     if block_size_arg in {"auto", ""}:
         block_size: int = 65536
     else:
@@ -1273,10 +1272,13 @@ def cli_mkpfs_pack_file_run(args: argparse.Namespace) -> int:
     if not source_file.exists() or not source_file.is_file():
         raise BuildError(f"--source-file must be an existing file: {source_file}")
 
-    # Prefer direct streaming for the common single-file path, fall back to the
-    # legacy staged/spool builder only when the requested options require it.
-    if _can_stream_pack_file(args=args):
+    # Prefer direct-to-image streaming for the common single-file path; fall back to
+    # the legacy staged/spool builder only when forced or when options require it.
+    reason: str | None = _stream_fallback_reason(args=args)
+    if not getattr(args, "use_spool", False) and reason is None:
         return _run_stream_pack_file(args=args, source_file=source_file)
+    if not getattr(args, "use_spool", False) and reason is not None:
+        info(f"Direct-to-image streaming unavailable ({reason}); using the spool builder.")
 
     with _stage_single_file_source_root(source_file=source_file, temp_folder=temp_folder) as staging_root:
         return _run_pack_build(
@@ -1576,11 +1578,11 @@ def cli_mkpfs_main_parsers() -> argparse.ArgumentParser:
         include_require_game_files=False,
     )
     file_parser.add_argument(
-        "--no-spool",
+        "--use-spool",
         action="store_true",
         help=(
-            "Prefer direct-to-image streaming for single-file packing; this is already the default when supported, "
-            "and unsupported option combinations fall back to the legacy spool path"
+            "Force the legacy staged/spool builder for single-file packing instead of the default "
+            "direct-to-image streaming"
         ),
     )
     file_parser.set_defaults(

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -110,7 +110,7 @@ class CliTestCase(unittest.TestCase):
             signed=False,
             encrypted=False,
             ekpfs_key=None,
-            no_spool=False,
+            use_spool=False,
             verbose=False,
             dry_run=dry_run,
             verify=verify,
@@ -1711,8 +1711,8 @@ class TestRunImageCheck(CliTestCase):
         self.assertTrue(any("orphan inodes" in item for item in errors))
 
 
-class TestCliPackFileNoSpool(CliTestCase):
-    """Tests for the spool-free streaming flag on the file pack path."""
+class TestCliPackFileStreaming(CliTestCase):
+    """Tests for streaming-by-default single-file packing and the --use-spool opt-out."""
 
     def test_pack_file_stream_auto_block_size_defaults_min_compress_size_to_65536(self) -> None:
         """Streaming single-file mode should map min_compress_size=0 to the auto block-size value."""
@@ -1739,14 +1739,13 @@ class TestCliPackFileNoSpool(CliTestCase):
         out: Path = tmp_path / "payload.ffpfsc"
         args: SimpleNamespace = self.make_pack_file_args(source_path=src, image_path=out, dry_run=True, verify=False)
         args.block_size = "auto-fit"
-        args.no_spool = True
         with patch.object(cli, "build_pfs", return_value=self.make_build_stats(tmp_path)) as mocked_build:
             self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
         resolved_block_size: int = mocked_build.call_args.kwargs["block_size"]
         self.assertEqual(mocked_build.call_args.kwargs["min_compress_size"], resolved_block_size)
 
-    def test_pack_file_no_spool_creates_image_without_spool(self) -> None:
-        """`pack file --no-spool` writes the image and leaves no spool in the temp folder."""
+    def test_pack_file_streams_by_default_without_spool(self) -> None:
+        """`pack file` streams by default and leaves no spool in the temp folder."""
         tmp_path: Path = self.make_temp_path()
         src: Path = tmp_path / "PPSA.exfat"
         src.write_bytes(b"DATA" * 20000 + b"\x00" * 60000)
@@ -1767,7 +1766,6 @@ class TestCliPackFileNoSpool(CliTestCase):
                     "PS5",
                     "--inode-bits",
                     "32",
-                    "--no-spool",
                     "--temp-folder",
                     str(temp),
                     "--no-adjust-output-file-extension",
@@ -1777,15 +1775,14 @@ class TestCliPackFileNoSpool(CliTestCase):
         self.assertTrue(out.exists())
         self.assertEqual(list(temp.glob("mkpfs-*.pfsc")), [])
 
-    def test_pack_file_no_spool_falls_back_for_signed(self) -> None:
-        """Combining --no-spool with --signed should fall back to the legacy builder."""
+    def test_pack_file_use_spool_forces_legacy_builder(self) -> None:
+        """`--use-spool` forces the legacy staged/spool builder even when streaming is supported."""
         tmp_path: Path = self.make_temp_path()
         src: Path = tmp_path / "x.exfat"
         src.write_bytes(b"x" * 1000)
         out: Path = tmp_path / "x.ffpfsc"
         args: SimpleNamespace = self.make_pack_file_args(source_path=src, image_path=out, dry_run=True, verify=False)
-        args.no_spool = True
-        args.signed = True
+        args.use_spool = True
         with patch.object(
             cli, "_run_stream_pack_file", side_effect=AssertionError("streaming should not run")
         ), patch.object(
@@ -1796,14 +1793,30 @@ class TestCliPackFileNoSpool(CliTestCase):
             self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
         mocked_pack.assert_called_once()
 
-    def test_pack_folder_does_not_accept_no_spool(self) -> None:
-        """The --no-spool flag is only available on the file path, not the folder path."""
+    def test_pack_file_falls_back_for_signed_with_notice(self) -> None:
+        """`--signed` falls back to the legacy builder and prints a notice."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "x.exfat"
+        src.write_bytes(b"x" * 1000)
+        out: Path = tmp_path / "x.ffpfsc"
+        args: SimpleNamespace = self.make_pack_file_args(source_path=src, image_path=out, dry_run=True, verify=False)
+        args.signed = True
+        buffer: StringIO = StringIO()
+        with patch.object(
+            cli, "_run_stream_pack_file", side_effect=AssertionError("streaming should not run")
+        ), patch.object(cli, "_run_pack_build", return_value=0) as mocked_pack, redirect_stdout(buffer):
+            self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
+        mocked_pack.assert_called_once()
+        self.assertIn("signed images", buffer.getvalue())
+
+    def test_pack_folder_does_not_accept_use_spool(self) -> None:
+        """The --use-spool flag is only available on the file path, not the folder path."""
         parser: argparse.ArgumentParser = cli.cli_mkpfs_main_parsers()
         with self.assertRaises(SystemExit):
-            parser.parse_args(["pack", "folder", "src", "out", "--no-spool"])
+            parser.parse_args(["pack", "folder", "src", "out", "--use-spool"])
 
-    def test_pack_file_no_spool_with_verify_succeeds(self) -> None:
-        """`pack file --no-spool --verify` completes the post-create check without errors."""
+    def test_pack_file_streaming_with_verify_succeeds(self) -> None:
+        """`pack file --verify` completes the post-create check without errors."""
         tmp_path: Path = self.make_temp_path()
         src: Path = tmp_path / "PPSA.exfat"
         src.write_bytes(b"GAMEDATA" * 20000 + b"\x00" * 200000)
@@ -1822,7 +1835,6 @@ class TestCliPackFileNoSpool(CliTestCase):
                     "PS5",
                     "--inode-bits",
                     "32",
-                    "--no-spool",
                     "--verify",
                     "--temp-folder",
                     str(tmp_path / "temp"),
@@ -1831,7 +1843,7 @@ class TestCliPackFileNoSpool(CliTestCase):
             )
         self.assertEqual(rc, 0)
 
-    def test_pack_file_no_spool_prints_parameters_and_progress(self) -> None:
+    def test_pack_file_streaming_prints_parameters_and_progress(self) -> None:
         """The streaming path prints the parameters banner and a compression status line."""
         tmp_path: Path = self.make_temp_path()
         src: Path = tmp_path / "PPSA.exfat"
@@ -1852,7 +1864,6 @@ class TestCliPackFileNoSpool(CliTestCase):
                     "PS5",
                     "--inode-bits",
                     "32",
-                    "--no-spool",
                     "--temp-folder",
                     str(tmp_path / "temp"),
                     "--no-adjust-output-file-extension",
@@ -1864,14 +1875,13 @@ class TestCliPackFileNoSpool(CliTestCase):
         self.assertIn("Source path:", combined)
         self.assertIn("Compressing 1 file", combined)
 
-    def test_pack_file_no_spool_falls_back_for_inode_bits_64(self) -> None:
-        """64-bit inode requests should fall back to the legacy single-file builder."""
+    def test_pack_file_falls_back_for_inode_bits_64(self) -> None:
+        """64-bit inode requests fall back to the legacy single-file builder."""
         tmp_path: Path = self.make_temp_path()
         src: Path = tmp_path / "x.exfat"
         src.write_bytes(b"x" * 1000)
         out: Path = tmp_path / "x.ffpfsc"
         args: SimpleNamespace = self.make_pack_file_args(source_path=src, image_path=out, dry_run=True, verify=False)
-        args.no_spool = True
         args.inode_bits = 64
         with patch.object(
             cli, "_run_stream_pack_file", side_effect=AssertionError("streaming should not run")
@@ -1883,14 +1893,13 @@ class TestCliPackFileNoSpool(CliTestCase):
             self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
         mocked_pack.assert_called_once()
 
-    def test_pack_file_no_spool_falls_back_for_auto_fit_block_size(self) -> None:
-        """Auto-fit block size requests should fall back to the legacy single-file builder."""
+    def test_pack_file_falls_back_for_auto_fit_block_size(self) -> None:
+        """Auto-fit block size requests fall back to the legacy single-file builder."""
         tmp_path: Path = self.make_temp_path()
         src: Path = tmp_path / "x.exfat"
         src.write_bytes(b"x" * 1000)
         out: Path = tmp_path / "x.ffpfsc"
         args: SimpleNamespace = self.make_pack_file_args(source_path=src, image_path=out, dry_run=True, verify=False)
-        args.no_spool = True
         args.block_size = "auto-fit"
         with patch.object(
             cli, "_run_stream_pack_file", side_effect=AssertionError("streaming should not run")
@@ -1902,8 +1911,8 @@ class TestCliPackFileNoSpool(CliTestCase):
             self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
         mocked_pack.assert_called_once()
 
-    def test_pack_file_no_spool_dry_run_writes_nothing(self) -> None:
-        """--no-spool --dry-run reports layout without writing an image."""
+    def test_pack_file_streaming_dry_run_writes_nothing(self) -> None:
+        """`pack file --dry-run` reports layout without writing an image."""
         tmp_path: Path = self.make_temp_path()
         src: Path = tmp_path / "PPSA.exfat"
         src.write_bytes(b"DATA" * 20000 + b"\x00" * 60000)
@@ -1913,7 +1922,7 @@ class TestCliPackFileNoSpool(CliTestCase):
             StringIO()
         ):
             rc: int = cli_mkpfs_main(
-                ["pack", "file", str(src), str(out), "--no-spool", "--dry-run", "--no-adjust-output-file-extension"]
+                ["pack", "file", str(src), str(out), "--dry-run", "--no-adjust-output-file-extension"]
             )
         self.assertEqual(rc, 0)
         self.assertFalse(out.exists())


### PR DESCRIPTION
## Summary

`mkpfs pack file` now uses the direct-to-image streaming builder by default.
Previously streaming required the explicit `--no-spool` flag (which had already become a no-op since the dispatch picked streaming automatically). This PR makes the default explicit and adds a clean opt-out and fallback behavior:

- The vestigial `--no-spool` flag is replaced by `--use-spool`, which forces the legacy staged/spool builder.
- Option combinations the streaming builder cannot serve automatically fall back to the legacy spool builder, with an on-screen notice explaining why.

Output is unchanged: the streaming and spool builders produce byte-identical images (covered by the existing golden test).

| Invocation | Path | Notice |
| --- | --- | --- | 
| `pack file X Y` (and most flags) | streaming | none |
| `pack file X Y --use-spool` | legacy spool | none (explicit) |
| `pack file X Y --signed` | legacy spool | "signed images" |
| `pack file X Y --inode-bits 64` | legacy spool | "64-bit inodes" |
| `pack file X Y --block-size auto-fit` | legacy spool | "auto-fit block size" |

The notice reads, e.g.:
`Direct-to-image streaming unavailable (signed images); using the spool builder.`

## Why

Streaming keeps peak disk to source + output (no temp spool) and keeps memory flat, so it is the better default for the common single-file case (for example a large `.exfat`). The three excluded options genuinely require the legacy path (signed layout, 64-bit inodes, and multi-file auto-fit are not represented by the single-file streaming builder), so they transparently use it instead of erroring.

## Details

- New `_stream_fallback_reason(args) -> str | None` is the single source of truth for the dispatch decision and the notice text (replaces the boolean `_can_stream_pack_file`). 
- `cli_mkpfs_pack_file_run` streams only when no fallback reason applies and `--use-spool` was not passed; otherwise it routes to the existing `_run_pack_build` staged/spool path.
- Removed the now-unreachable `--block-size auto-fit` guard inside the streaming runner (the dispatch routes auto-fit to the spool path before it is reached).
- `--use-spool` is exposed on the `pack file` parser only (the `pack folder` path always uses the spool builder). 

## Docs

README updated: `pack file` usage and option table now document `--use-spool`, the notes describe the streaming default plus the automatic fallback and notice, and the incorrect `--no-spool` entry was removed from the `pack folder` sections (it was always file-only).

## Testing

- `uv run --frozen pytest`: full suite green (268 tests); `ruff` clean.
- Tests cover: flagless `pack file` streams with no spool artifact, `--use-spool` forces the legacy builder, and `--signed` / `--inode-bits 64` / `--block-size auto-fit` fall back with the notice.
- Manual smoke confirmed each path end-to-end (default streams, auto-fit prints the notice and uses spool, `--use-spool` uses spool with no notice).