### PR TITLE
fix: clean PFSC spools after compression failures

### DIFF
--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -1351,23 +1351,28 @@ def _encode_pfsc_file_to_spool(
     Returns:
         Tuple ``(stored_size, is_compressed, gain_pct, hypothetical_all_compressed_size)``.
     """
-    with spool_path.open("w+b") as spool_file:
-        stored_size: int
-        is_compressed: bool
-        gain_pct: float
-        hypothetical_all_compressed_size: int
-        stored_size, is_compressed, gain_pct, hypothetical_all_compressed_size = _encode_pfsc_into_handle(
-            out=spool_file,
-            base_offset=0,
-            source_path=abs_path,
-            threshold_gain=threshold_gain,
-            min_file_gain=min_file_gain,
-            zlib_level=zlib_level,
-            logical_block_size=logical_block_size,
-            block_worker_count=block_worker_count,
-            progress_callback=progress_callback,
-        )
-        spool_file.truncate(stored_size)
+    try:
+        with spool_path.open("w+b") as spool_file:
+            stored_size: int
+            is_compressed: bool
+            gain_pct: float
+            hypothetical_all_compressed_size: int
+            stored_size, is_compressed, gain_pct, hypothetical_all_compressed_size = _encode_pfsc_into_handle(
+                out=spool_file,
+                base_offset=0,
+                source_path=abs_path,
+                threshold_gain=threshold_gain,
+                min_file_gain=min_file_gain,
+                zlib_level=zlib_level,
+                logical_block_size=logical_block_size,
+                block_worker_count=block_worker_count,
+                progress_callback=progress_callback,
+            )
+            spool_file.truncate(stored_size)
+    except OSError:
+        with suppress(OSError):
+            spool_path.unlink()
+        raise
     return stored_size, is_compressed, gain_pct, hypothetical_all_compressed_size
 
 
@@ -1632,6 +1637,22 @@ def _compress_files_in_process(
             progress_total_units,
             bytes_processed=total_bytes_to_process if total_bytes_to_process > 0 else 0,
         )
+
+
+def cleanup_temporary_file_node_payloads(*, file_nodes: list[FileNode]) -> None:
+    """Remove temporary payload files already assigned to file nodes.
+
+    Args:
+        file_nodes: File nodes that may reference PFSC spool files.
+    """
+    file_node: FileNode
+    for file_node in file_nodes:
+        if not file_node.stored_source_is_temp or file_node.stored_source_path is None:
+            continue
+        with suppress(OSError):
+            file_node.stored_source_path.unlink()
+        file_node.stored_source_path = None
+        file_node.stored_source_is_temp = False
 
 
 def _parse_pfsc_header(head: bytes) -> tuple[int, int, int, int, int]:
@@ -2564,18 +2585,22 @@ def build_pfs(
         if worker_count == 1 or len(compression_file_nodes) == 1:
             # Single-worker or single-file path uses in-process flow so a large file
             # can leverage block-level multiprocessing inside one file.
-            _compress_files_in_process(
-                file_nodes_sorted=compression_file_nodes,
-                threshold_gain=threshold_gain,
-                min_file_gain=min_file_gain,
-                min_compress_size=min_compress_size,
-                zlib_level=zlib_level,
-                compression_cpu_count=compression_cpu_count,
-                dry_run=dry_run,
-                total_bytes_to_process=total_bytes_to_process,
-                progress=progress,
-                temp_folder=temp_root,
-            )
+            try:
+                _compress_files_in_process(
+                    file_nodes_sorted=compression_file_nodes,
+                    threshold_gain=threshold_gain,
+                    min_file_gain=min_file_gain,
+                    min_compress_size=min_compress_size,
+                    zlib_level=zlib_level,
+                    compression_cpu_count=compression_cpu_count,
+                    dry_run=dry_run,
+                    total_bytes_to_process=total_bytes_to_process,
+                    progress=progress,
+                    temp_folder=temp_root,
+                )
+            except OSError:
+                cleanup_temporary_file_node_payloads(file_nodes=compression_file_nodes)
+                raise
         else:
             # Use multiprocessing for parallel compression.
             progress_total_units: int = (
@@ -2623,6 +2648,9 @@ def build_pfs(
                             result = results.next(timeout=0.1)
                         except mp.TimeoutError:
                             continue
+                        except OSError:
+                            cleanup_temporary_file_node_payloads(file_nodes=compression_file_nodes)
+                            raise
 
                         remaining_results -= 1
                         (

--- a/tests/mkpfs/test_pfs.py
+++ b/tests/mkpfs/test_pfs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import io
 import json
 import random
@@ -440,6 +441,85 @@ class TestEncryptedImageRoundTrip(PfsTestCase):
             )
 
         assert out.is_file()
+
+    def test_build_pfs_removes_completed_spools_when_later_compression_fails(self) -> None:
+        """Compression failures should remove temp spools from earlier files."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = make_app_with_nested_dirs(tmp_path / "src")
+        first_file: Path = src / "data" / "aaa-first.bin"
+        second_file: Path = src / "data" / "bbb-second.bin"
+        first_file.write_bytes(b"A" * 200000)
+        second_file.write_bytes(b"B" * 200000)
+        out: Path = tmp_path / "failed-compression.ffpfs"
+        temp_folder: Path = tmp_path / "pack-temp"
+        temp_folder.mkdir()
+        expected_temp_folder: Path = temp_folder
+        first_spool: Path = temp_folder / "mkpfs-aaa-first.bin.pfsc"
+        second_spool: Path = temp_folder / "mkpfs-bbb-second.bin.pfsc"
+
+        def fake_encode_pfsc_file_to_spool(
+            *,
+            abs_path: Path,
+            spool_path: Path,
+            threshold_gain: int,
+            min_file_gain: int,
+            zlib_level: int,
+            logical_block_size: int,
+            block_worker_count: int = 1,
+            progress_callback: Callable[[int], None] | None = None,
+        ) -> tuple[int, bool, float, int]:
+            """Create one successful spool, then fail the next compression."""
+            del threshold_gain, min_file_gain, zlib_level, logical_block_size, block_worker_count
+            if progress_callback is not None:
+                progress_callback(abs_path.stat().st_size)
+            if abs_path.name == "aaa-first.bin":
+                spool_path.write_bytes(b"PFSC-first")
+                return len(b"PFSC-first"), True, 90.0, len(b"PFSC-first")
+            if abs_path.name == "bbb-second.bin":
+                spool_path.write_bytes(b"partial")
+                raise OSError(errno.ENOSPC, "No space left on device")
+            return abs_path.stat().st_size, False, 0.0, 0
+
+        def fake_make_compression_spool_path(*, source_path: Path, temp_folder: Path | None = None) -> Path:
+            """Return deterministic spool paths for cleanup assertions."""
+            assert temp_folder == expected_temp_folder
+            if source_path.name == "aaa-first.bin":
+                return first_spool
+            if source_path.name == "bbb-second.bin":
+                return second_spool
+            if temp_folder is not None:
+                return temp_folder / f"mkpfs-{source_path.name}.pfsc"
+            return tmp_path / source_path.name
+
+        with patch.object(
+            pfs_mod,
+            "_encode_pfsc_file_to_spool",
+            side_effect=fake_encode_pfsc_file_to_spool,
+        ), patch.object(
+            pfs_mod,
+            "_make_compression_spool_path",
+            side_effect=fake_make_compression_spool_path,
+        ), self.assertRaises(OSError):
+            build_pfs(
+                source_root=src,
+                output_path=out,
+                block_size=65536,
+                pfs_version=c.PFS_VERSION_PS4,
+                inode_bits=32,
+                case_insensitive=True,
+                signed=False,
+                compress=True,
+                threshold_gain=1,
+                cpu_count=1,
+                zlib_level=9,
+                dry_run=False,
+                verbose=False,
+                encrypted=False,
+                min_compress_size=1000,
+                temp_folder=temp_folder,
+            )
+
+        assert not first_spool.exists()
 
     def test_executable_compression_skip_keeps_eboot_prx_and_sprx_raw(self) -> None:
         """Requested executable compression skips should leave eboot*.bin, *.prx, and *.sprx inodes raw."""


### PR DESCRIPTION
The streaming PFSC encoder can leave temporary spool files behind when encoding fails after opening or partially writing the spool. Later compression stages can also fail after some file nodes already point at temporary payloads. In both cases, a failed pack can strand large PFSC spool files in the temp folder.

Remove the spool path when _encode_pfsc_file_to_spool raises OSError. Add a shared cleanup helper for temporary payloads already assigned to file nodes, and call it when in-process or multiprocessing compression aborts after some temp payloads have been produced.

This keeps failure paths symmetric with the successful discard path for incompressible files and prevents repeated retries from accumulating stale large temp artifacts.