### PR TITLE
Fixed corrupted PFS images on large game folders caused by wrong inode mapping in flat_path_table

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -18,18 +18,18 @@ template: |
   python -m pip install -U "mkpfs"
   
   # Creating Images: Option 1: .exfat -> .ffpfsc (Works with ShadowMountPlus)  (Maximum compatibility)
-  python -m mkpfs pack file './BREW1234.exfat' './BREW1234.exfat.ffpfsc'
+  python -m mkpfs pack file --verify './BREW1234.exfat' './BREW1234.exfat.ffpfsc'
   
   # Creating Images: Option 2: .ffpkg -> .ffpfsc (Works with ShadowMountPlus) 
-  python -m mkpfs pack file './BREW1234.ffpkg' './BREW1234.ffpkg.ffpfsc'
+  python -m mkpfs pack file --verify './BREW1234.ffpkg' './BREW1234.ffpkg.ffpfsc'
   
   # Creating Images: Option 3: Game folder wrapped twice into .ffpfsc (two-pass) (Works with ShadowMountPlus) 
-  python -m mkpfs pack folder --no-compress --no-adjust-output-file-extension './BREW1234-app' './pfs_image.dat'
-  python -m mkpfs pack file './pfs_image.dat' './BREW1234.ffpfsc'
+  python -m mkpfs pack folder --verify --no-compress --no-adjust-output-file-extension './BREW1234-app' './pfs_image.dat'
+  python -m mkpfs pack file --verify './pfs_image.dat' './BREW1234.ffpfsc'
   rm './pfs_image.dat'
   
   # Creating Images: Option 4: Game folder without a wrapper (single-pass) (Experimental) (Works with ShadowMountPlus) 
-  python -m mkpfs pack folder './BREW1234-app/' './BREW1234.ffpfsc'
+  python -m mkpfs pack folder --verify './BREW1234-app/' './BREW1234.ffpfsc'
   
   # Extracting Existing Images (Reverse operation)
   python -m mkpfs unpack './BREW1234.ffpfs' './BREW1234-extracted/'

--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ MkPFS is designed to be a clean and practical entry point for PlayStation PFS im
 python -m pip install -U "mkpfs"
 
 # Creating Images: Option 1: .exfat -> .ffpfsc (Works with ShadowMountPlus)  (Maximum compatibility)
-python -m mkpfs pack file './BREW1234.exfat' './BREW1234.exfat.ffpfsc'
+python -m mkpfs pack file --verify './BREW1234.exfat' './BREW1234.exfat.ffpfsc'
 
 # Creating Images: Option 2: .ffpkg -> .ffpfsc (Works with ShadowMountPlus) 
-python -m mkpfs pack file './BREW1234.ffpkg' './BREW1234.ffpkg.ffpfsc'
+python -m mkpfs pack file --verify './BREW1234.ffpkg' './BREW1234.ffpkg.ffpfsc'
 
 # Creating Images: Option 3: Game folder wrapped twice into .ffpfsc (two-pass) (Works with ShadowMountPlus) 
-python -m mkpfs pack folder --no-compress --no-adjust-output-file-extension './BREW1234-app' './pfs_image.dat'
-python -m mkpfs pack file './pfs_image.dat' './BREW1234.ffpfsc'
+python -m mkpfs pack folder --verify --no-compress --no-adjust-output-file-extension './BREW1234-app' './pfs_image.dat'
+python -m mkpfs pack file --verify './pfs_image.dat' './BREW1234.ffpfsc'
 rm './pfs_image.dat'
 
 # Creating Images: Option 4: Game folder without a wrapper (single-pass) (Experimental) (Works with ShadowMountPlus) 
-python -m mkpfs pack folder './BREW1234-app/' './BREW1234.ffpfsc'
+python -m mkpfs pack folder --verify './BREW1234-app/' './BREW1234.ffpfsc'
 
 # Extracting Existing Images (Reverse operation)
 python -m mkpfs unpack './BREW1234.ffpfs' './BREW1234-extracted/'

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -2840,6 +2840,17 @@ def build_pfs(
         for f in file_nodes_sorted:
             inode_by_path[f"file:{f.rel_path}"] = f.inode
 
+        # Rebuild FPT and collision blobs now that inode numbers have been
+        # shifted by the insertion of the collision_inode at slot 2. The
+        # initial blobs encoded pre-renumber inode numbers, which would
+        # cause every FPT entry to be off by one on verify.
+        fpt_blob, collision_blob, _ = make_fpt_and_collision_blob(
+            dirs_sorted=dir_nodes_sorted,
+            files_sorted=file_nodes_sorted,
+            inode_by_path=inode_by_path,
+            case_insensitive=case_insensitive,
+        )
+
     super_root_dirents: list[Dirent] = [Dirent(fpt_inode.number, consts.DIRENT_TYPE_FILE, "flat_path_table")]
     if has_collision and collision_inode is not None:
         super_root_dirents.append(Dirent(collision_inode.number, consts.DIRENT_TYPE_FILE, "collision_resolver"))

--- a/tests/mkpfs/test_pfs.py
+++ b/tests/mkpfs/test_pfs.py
@@ -624,7 +624,18 @@ class TestEncryptedImageRoundTrip(PfsTestCase):
             assert pfs_mod.read_image_inode_payload(fh, header, large_inode)[:4] == b"PFSC"
 
     def test_build_pfs_handles_fpt_collision_inode_renumbering(self) -> None:
-        """Forced FPT collisions should not break inode renumbering during build."""
+        """Forced FPT collisions should not break inode renumbering during build.
+
+        When the collision resolver inode is inserted at slot 2 all subsequent
+        inode numbers are shifted by one.  The flat_path_table must be rebuilt
+        with the post-renumber inode numbers so that FPT entries match the
+        directory tree on verify.  A regression was present where the FPT was
+        built before the renumber step, causing every entry to be off by one.
+
+        The fpt_hash patch must also be active during inspection so that both
+        the on-disk table and the expected table are built with the same hash
+        function.
+        """
         tmp_path: Path = self.make_temp_path()
         src: Path = make_app_with_nested_dirs(tmp_path / "src")
         out: Path = tmp_path / "collision-renumbering.ffpfs"
@@ -647,8 +658,21 @@ class TestEncryptedImageRoundTrip(PfsTestCase):
                 encrypted=False,
             )
 
-        assert out.is_file()
-        assert out.stat().st_size > 0
+            assert out.is_file()
+            assert out.stat().st_size > 0
+
+            # Verify that the FPT inode numbers match the directory tree exactly.
+            # The patch must remain active so that build_expected_fpt uses the same
+            # hash function as the on-disk table.  Before the fix, the collision
+            # blob embedded pre-renumber inode numbers so every entry would be off
+            # by one.
+            inspection: pfs_mod.PFSImageInspection = inspect_pfs_image(image=out)
+
+        fpt_errors: list[str] = [
+            e for e in inspection.errors if "mismatch" in e or "flat_path_table" in e or "collision" in e
+        ]
+        assert fpt_errors == [], f"FPT/collision errors after collision renumber: {fpt_errors}"
+        assert inspection.errors == [], f"Unexpected errors after collision renumber build: {inspection.errors}"
 
     def test_pfsc_encode_decode_round_trip(self) -> None:
         """PFSC payload encoding and decoding should preserve logical bytes."""


### PR DESCRIPTION
## Problem

Packing large game backup folders with many files (100k+ files, 50 GB+) produced PFS images that failed verification with hundreds of errors like the ones below, making the image impossible to mount or it would show up corrupted. 

This bug had a tiny probability of happen per inode, but lager the folder was, more and more probable it would become to happen. 

```
hash 0xFFF3D1D8 mismatch: actual inode=152161 dir=False, expected inode=152162 dir=False
hash 0xFFF3E193 mismatch: actual inode=23089 dir=False, expected inode=23090 dir=False
...
```

Every `flat_path_table` entry was pointing to the wrong inode - consistently off by one.

## Root Cause

When two or more paths produce the same FPT hash (collision), a `collision_resolver` inode is inserted at slot 2. This shifts every subsequent inode number by +1 (uroot moves from 2 to 3, all dirs and files follow). The directory entries (`dirents`) were correctly remapped via a `remap` dict. However, the `flat_path_table` and `collision_resolver` blobs were serialized **before** this renumber step and were never rebuilt. So they kept encoding the pre-shift inode numbers, causing every FPT lookup to resolve to the wrong inode.

On large trees, natural FPT hash collisions are virtually guaranteed, making this bug reproducible for any game folder with 100k+ files.

## Fix

After the `inode_by_path` map is rebuilt with the renumbered inodes, `make_fpt_and_collision_blob` is called a second time to produce blobs that encode the correct post-renumber inode numbers.

The existing regression test was also strengthened to assert that `inspect_pfs_image` returns no FPT or collision errors when a forced collision scenario is exercised.
