### PR TITLE
Warn when packing game/app folders directly with compression enabled or invalid configs

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -2,10 +2,6 @@ name-template: '$RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
 template: |
   # 🎉 MkPFS $RESOLVED_VERSION is released!
-  
-  MkPFS is a command-line tool and Python library for building, verifying, inspecting, browsing, and extracting 
-  PlayStation FileSystem (PFS) disk images. It works with common image naming conventions such as `.ffpfs`, `.ffpfsc`,
-  `.pfs`, `.dat`, and `.bin`, and fits both direct image workflows and PKG or FPKG inner-PFS generation.
 
   ## 🤖 What's Changed
   
@@ -18,34 +14,37 @@ template: |
   python -m pip install -U "mkpfs"
   
   # Creating Images: Option 1: .exfat -> .ffpfsc (Works with ShadowMountPlus)  (Maximum compatibility)
-  python -m mkpfs pack file --verify './BREW1234.exfat' './BREW1234.exfat.ffpfsc'
+  python -m mkpfs pack file --verify './BREW1234.exfat' './BREW1234.ffpfsc'
   
   # Creating Images: Option 2: .ffpkg -> .ffpfsc (Works with ShadowMountPlus) 
-  python -m mkpfs pack file --verify './BREW1234.ffpkg' './BREW1234.ffpkg.ffpfsc'
+  python -m mkpfs pack file --verify './BREW1234.ffpkg' './BREW1234.ffpfsc'
   
   # Creating Images: Option 3: Game folder wrapped twice into .ffpfsc (two-pass) (Works with ShadowMountPlus) 
   python -m mkpfs pack folder --verify --no-compress --no-adjust-output-file-extension './BREW1234-app' './pfs_image.dat'
   python -m mkpfs pack file --verify './pfs_image.dat' './BREW1234.ffpfsc'
   rm './pfs_image.dat'
   
-  # Creating Images: Option 4: Game folder without a wrapper (single-pass) (Experimental) (Works with ShadowMountPlus) 
-  python -m mkpfs pack folder --verify './BREW1234-app/' './BREW1234.ffpfsc'
+  # Creating Images: Option 4: Game folder without a wrapper (single-pass) (--no-compress) (Avoid; See Notes!)
+  python -m mkpfs pack folder --no-compress --verify './BREW1234-app/' './BREW1234.ffpfs'
   
   # Extracting Existing Images (Reverse operation)
   python -m mkpfs unpack './BREW1234.ffpfs' './BREW1234-extracted/'
   ```
+  
+  ## ⚠️ Limitations and Known Issues
+  
+  - `exfat->ffpfsc` is currently the most stable format for compressed game backups.
+  - Packing an application folder directly into an image without a wrapper (single-pass) does not work when 
+    file compression is enabled. Although the image is created and verification passes, the console reads the files 
+    incorrectly due to technical limitations, so this option provides no practical benefit.
+  - With the default `--block-size 65536`, very small files can cause significant block-alignment waste, which may make
+    the resulting image larger than the source in corner cases.
+      - For small-file-heavy folders, prefer the two-pass strategy (`raw-folder -> .dat -> .ffpfsc`) or try a smaller
+        block size such as `--block-size 16384` or `--block-size 32768`.
+  - Antivirus scanning can reduce conversion speed, especially during the write phase or when processing many loose
+    files. If you trust this software in your environment and need higher throughput, temporarily disabling real-time
+    scanning can help. If you are unsure, keep antivirus enabled and expect slower conversions.
 
-  **Note on conversion speed:** 
-  
-  - Antivirus scanning can reduce conversion speed, especially during the writing phase or when processing many loose files. 
-    If you plan to convert many titles in bulk and you trust this software in your environment, you may temporarily disable 
-    real-time antivirus protection to speed up the process. If you are unsure, keep antivirus enabled and expect slower conversions.
-  
-  **Notes on stability:**
-  
-  - `exfat->ffpfsc` is the most stable solution at this moment.
-  - raw folder compression works, but has limitations for large game backups or if the folder contains too many small files. In that case, use `exfat->ffpfsc` instead.
-  
   ## 💖 Sponsorship
   
   MkPFS is easier to sustain when users who benefit from it help fund it.

--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ MkPFS is designed to be a clean and practical entry point for PlayStation PFS im
 python -m pip install -U "mkpfs"
 
 # Creating Images: Option 1: .exfat -> .ffpfsc (Works with ShadowMountPlus)  (Maximum compatibility)
-python -m mkpfs pack file --verify './BREW1234.exfat' './BREW1234.exfat.ffpfsc'
+python -m mkpfs pack file --verify './BREW1234.exfat' './BREW1234.ffpfsc'
 
 # Creating Images: Option 2: .ffpkg -> .ffpfsc (Works with ShadowMountPlus) 
-python -m mkpfs pack file --verify './BREW1234.ffpkg' './BREW1234.ffpkg.ffpfsc'
+python -m mkpfs pack file --verify './BREW1234.ffpkg' './BREW1234.ffpfsc'
 
 # Creating Images: Option 3: Game folder wrapped twice into .ffpfsc (two-pass) (Works with ShadowMountPlus) 
 python -m mkpfs pack folder --verify --no-compress --no-adjust-output-file-extension './BREW1234-app' './pfs_image.dat'
 python -m mkpfs pack file --verify './pfs_image.dat' './BREW1234.ffpfsc'
 rm './pfs_image.dat'
 
-# Creating Images: Option 4: Game folder without a wrapper (single-pass) (Experimental) (Works with ShadowMountPlus) 
-python -m mkpfs pack folder --verify './BREW1234-app/' './BREW1234.ffpfsc'
+# Creating Images: Option 4: Game folder without a wrapper (single-pass) (--no-compress) (Avoid; See Notes!)
+python -m mkpfs pack folder --no-compress --verify './BREW1234-app/' './BREW1234.ffpfs'
 
 # Extracting Existing Images (Reverse operation)
 python -m mkpfs unpack './BREW1234.ffpfs' './BREW1234-extracted/'
@@ -51,8 +51,10 @@ python -m mkpfs unpack './BREW1234.ffpfs' './BREW1234-extracted/'
 
 ## ⚠️ Limitations and Known Issues
 
-- `exfat->ffpfsc` is currently the most stable workflow.
-- Direct raw-folder compression works, but it can be less efficient for large backups with many small files.
+- `exfat->ffpfsc` is currently the most stable format for compressed game backups.
+- Packing an application folder directly into an image without a wrapper (single-pass) does not work when 
+  file compression is enabled. Although the image is created and verification passes, the console reads the files 
+  incorrectly due to technical limitations, so this option provides no practical benefit.
 - With the default `--block-size 65536`, very small files can cause significant block-alignment waste, which may make
   the resulting image larger than the source in corner cases.
     - For small-file-heavy folders, prefer the two-pass strategy (`raw-folder -> .dat -> .ffpfsc`) or try a smaller

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -60,6 +60,18 @@ from .utils import (
 PROJECT_URL: str = "https://github.com/PSBrew/MkPFS"
 
 
+_GAME_FOLDER_COMPRESS_WARNING_TEXT: str = (
+    "IMPORTANT: Do not pack an application/game folder directly with compression enabled.\n"
+    "Although image creation and verification may succeed, the console often misreads compressed files.\n"
+    "Either turn off compression (--no-compress) or create the image using the wrapper-based packaging flow."
+)
+
+
+def _emit_game_folder_compression_warning() -> None:
+    """Emit the red warning about compressing direct game-folder images."""
+    warning(_GAME_FOLDER_COMPRESS_WARNING_TEXT, icon_name="warning")
+
+
 def get_help_title() -> str:
     """Build the version line shown at the top of CLI help output.
 
@@ -571,6 +583,19 @@ def run_image_check(
             total_logical = sum(max(0, inodes[i].logical_size) for i in file_inodes.values())
             total_stored = sum(max(0, inodes[i].stored_size) for i in file_inodes.values())
 
+            # If verification is running interactively (emit_report) and the image
+            # contains PS5 game markers (eboot.bin or sce_sys/param.json) while any
+            # file is stored compressed, emit a prominent red warning explaining
+            # that packing application folders directly with PFSC compression
+            # provides no practical benefit and may cause the console to read
+            # files incorrectly.
+            if (
+                emit_report
+                and compressed_count > 0
+                and ("eboot.bin" in file_inodes or "sce_sys/param.json" in file_inodes)
+            ):
+                _emit_game_folder_compression_warning()
+
             if emit_report:
                 payload_magic: str = describe_magic(magic=consts.PFSC_MAGIC) if compressed_count > 0 else "none"
                 print_version_header()
@@ -895,6 +920,27 @@ def _print_pack_parameters(
     )
 
 
+def _contains_direct_game_markers(root_path: Path) -> bool:
+    """Return whether a source directory exposes direct PS5 game markers.
+
+    Args:
+        root_path: Source directory root to inspect.
+
+    Returns:
+        True when ``eboot.bin`` or ``sce_sys/param.json`` exists directly under
+        the source root, otherwise False.
+    """
+    try:
+        has_eboot: bool = (root_path / "eboot.bin").exists()
+    except OSError:
+        has_eboot = False
+    try:
+        has_param: bool = (root_path / "sce_sys" / "param.json").exists()
+    except OSError:
+        has_param = False
+    return has_eboot or has_param
+
+
 def _run_post_pack_verify(
     *,
     output_path: Path,
@@ -1007,6 +1053,9 @@ def _run_pack_build(
         require_game_files=require_game_files,
         dry_run=args.dry_run,
     )
+
+    if config.compress and _contains_direct_game_markers(build_source_root):
+        _emit_game_folder_compression_warning()
 
     if not args.dry_run:
         destination_space_error: str | None = get_destination_space_error_message(

--- a/mkpfs/logging.py
+++ b/mkpfs/logging.py
@@ -45,10 +45,35 @@ def log(message: str, level: int = logging.INFO, icon_name: str | None = None) -
     """
     prefix: str = (icon(icon_name) + " ") if icon_name else ""
     text: str = prefix + str(message)
+    # Colorize output when terminal appears to support colors and the user has not
+    # disabled colors via MKPFS_NO_COLOR. Keep logic simple and fall back to plain
+    # output when unsure.
+    no_color_env: str | None = os.environ.get("MKPFS_NO_COLOR")
+    use_color: bool = False
+    try:
+        use_color = bool(
+            (getattr(sys.stderr, "isatty", lambda: False)() or getattr(sys.stdout, "isatty", lambda: False)())
+            and not no_color_env
+        )
+    except Exception:
+        use_color = False
+
+    color_code: str = ""
+    reset_code: str = ""
+    if use_color:
+        reset_code = "\x1b[0m"
+        if level >= logging.ERROR:
+            color_code = "\x1b[31m"  # red
+        elif level >= logging.WARNING:
+            color_code = "\x1b[38;5;208m"  # orange (256-color)
+        else:
+            color_code = ""
+
+    colored_text: str = f"{color_code}{text}{reset_code}" if color_code else text
     if level >= logging.ERROR:
-        print(text, file=sys.stderr)
+        print(colored_text, file=sys.stderr)
     else:
-        print(text, file=sys.stdout)
+        print(colored_text, file=sys.stdout)
 
 
 def info(message: str, icon_name: str | None = None) -> None:

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -1208,6 +1208,89 @@ class TestCliCreateRun(CliTestCase):
             self.assertEqual(staged_file.read_bytes(), source_file.read_bytes())
             mocked_copy.assert_called_once_with(source_file, staged_file)
 
+    def test_create_run_emits_red_warning_for_compressed_game_folder(self) -> None:
+        """Pack folder should emit the red warning for direct game folders when compression is enabled."""
+        tmp_path: Path = self.make_temp_path()
+        source_path: Path = self.make_valid_source(tmp_path)
+        output_path: Path = tmp_path / "out.ffpfs"
+        args: SimpleNamespace = self.make_create_args(
+            source_path=source_path,
+            image_path=output_path,
+            dry_run=True,
+            verify=False,
+        )
+        combined: StringIO = StringIO()
+        with patch.object(cli, "validate_input", return_value=("TITLE", [])), patch.object(
+            cli,
+            "build_pfs",
+            return_value=BuildStats(input_path=source_path, output_path=output_path),
+        ), redirect_stdout(combined), redirect_stderr(combined):
+            self.assertEqual(cli.cli_mkpfs_create_run(args), 0)
+
+        self.assertIn(cli._GAME_FOLDER_COMPRESS_WARNING_TEXT.splitlines()[0], combined.getvalue())
+
+    def test_run_image_check_emits_red_warning_for_compressed_game_marker_images(self) -> None:
+        """Verify should emit the red warning when a game-marker image contains any compressed file."""
+        tmp_path: Path = self.make_temp_path()
+        image_path: Path = tmp_path / "image.ffpfs"
+        image_path.write_bytes(b"x")
+        header: SimpleNamespace = SimpleNamespace(
+            mode=consts.PFS_MODE_CASE_INSENSITIVE,
+            version=consts.PFS_VERSION_PS5,
+            magic=123,
+            readonly=1,
+            block_size=65536,
+        )
+        inodes: list[SimpleNamespace] = [
+            SimpleNamespace(
+                number=0,
+                is_compressed=True,
+                size=100,
+                size_compressed=90,
+                logical_size=100,
+                stored_size=90,
+            ),
+            SimpleNamespace(
+                number=1,
+                is_compressed=False,
+                size=50,
+                size_compressed=50,
+                logical_size=50,
+                stored_size=50,
+            ),
+        ]
+        combined: StringIO = StringIO()
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(cli, "parse_image_header", return_value=header))
+            stack.enter_context(patch.object(cli, "parse_image_inodes", return_value=inodes))
+            stack.enter_context(patch.object(cli, "validate_inode_layout", return_value=None))
+            stack.enter_context(patch.object(cli, "verify_signed_image_signatures", return_value=None))
+            stack.enter_context(patch.object(cli, "parse_superroot_and_indexes", return_value=(0, {1: 2}, {}, {0})))
+            stack.enter_context(
+                patch.object(
+                    cli,
+                    "build_tree_from_uroot",
+                    return_value=({"eboot.bin": 0, "other.bin": 1}, {"": 0}, {0: []}),
+                )
+            )
+            stack.enter_context(patch.object(cli, "build_expected_fpt", return_value={1: []}))
+            stack.enter_context(patch.object(cli, "validate_fpt_maps", return_value=None))
+            stack.enter_context(patch.object(cli, "validate_ps5_checklist", return_value=None))
+            stack.enter_context(patch.object(cli, "verify_file_payload_hashes", return_value=(2, 0x1234, "a" * 64)))
+            stack.enter_context(redirect_stdout(combined))
+            stack.enter_context(redirect_stderr(combined))
+            errors, warnings, tree, uroot = cli.run_image_check(
+                image=image_path,
+                source=None,
+                print_tree=False,
+                emit_report=True,
+            )
+        self.assertEqual(errors, [])
+        self.assertEqual(warnings, [])
+        self.assertEqual(tree, {0: []})
+        self.assertEqual(uroot, 0)
+        self.assertIn(cli._GAME_FOLDER_COMPRESS_WARNING_TEXT.splitlines()[0], combined.getvalue())
+
 
 class TestCliReadOnlyCommands(CliTestCase):
     """Tests for verify, inspect, tree, info, analyze, extract, and entrypoint wrappers."""


### PR DESCRIPTION
## Summary

Add a prominent user-facing warning when a user attempts to pack a game or application folder directly into an image with PFSC compression enabled. The feature centralizes the message text, emits the warning at both pack time and during verification when compressed files are present, and updates tests to assert against the shared message constant.

> IMPORTANT: Do not pack an application/game folder directly with compression enabled.
> Although image creation and verification may succeed, the console often misreads compressed files.
> Either turn off compression (--no-compress) or create the image using the wrapper-based packaging flow."

## Changes

- mkpfs/cli.py
  - Introduce `_GAME_FOLDER_COMPRESS_WARNING_TEXT` constant containing the user-facing warning text.
  - Add `_emit_game_folder_compression_warning()` helper and call it from pack and verify paths.

- mkpfs/logging.py
  - Keep logging API but colorize output when running in a TTY: warnings print in orange, errors print in red. Use `MKPFS_NO_COLOR` env var to disable colors.

- tests/mkpfs/test_cli.py
  - Update tests to assert against the module-level warning constant and capture combined stdout/stderr where necessary to avoid brittle output assumptions.

## Test plan

- Run `./run-tests.sh` (will run ruff formatting/check and pytest) locally in your development environment.
- Focus checks on `tests/mkpfs/test_cli.py::TestCliCreateRun::test_create_run_emits_red_warning_for_compressed_game_folder` and `test_run_image_check_emits_red_warning_for_compressed_game_marker_images` which were updated to reference the shared constant.

## Notes

- Message text is centralized to reduce accidental drift and to make translations or wording tweaks straightforward.
- The CLI now uses ANSI colors when a TTY is detected; CI and tests can disable color by setting `MKPFS_NO_COLOR=1` or `MKPFS_NO_COLOR=TRUE`.