### PR TITLE
Make post-pack verification much faster by default

### DIFF
--- a/.claude/skills/pr-writing/SKILL.md
+++ b/.claude/skills/pr-writing/SKILL.md
@@ -165,3 +165,5 @@ Before publishing a commit message, PR body, or comment, check:
 - Is the language understandable to a non-technical reader?
 - Did you assign sensible labels that match release drafter?
 - Did you avoid mentioning any AI tools?
+- After editing with `gh`, did you re-read the final published PR title/body and confirm it still matches this skill instead of a generic Markdown template?
+- If a repository instruction says to use this skill for PR text, did you follow the full structure here rather than only invoking the skill tool?

--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -14,18 +14,18 @@ template: |
   python -m pip install -U "mkpfs"
   
   # Creating Images: Option 1: .exfat -> .ffpfsc (Works with ShadowMountPlus)  (Maximum compatibility)
-  python -m mkpfs pack file --verify './BREW1234.exfat' './BREW1234.ffpfsc'
+  python -m mkpfs pack file './BREW1234.exfat' './BREW1234.ffpfsc'
   
   # Creating Images: Option 2: .ffpkg -> .ffpfsc (Works with ShadowMountPlus) 
-  python -m mkpfs pack file --verify './BREW1234.ffpkg' './BREW1234.ffpfsc'
+  python -m mkpfs pack file './BREW1234.ffpkg' './BREW1234.ffpfsc'
   
   # Creating Images: Option 3: Game folder wrapped twice into .ffpfsc (two-pass) (Works with ShadowMountPlus) 
-  python -m mkpfs pack folder --verify --no-compress --no-adjust-output-file-extension './BREW1234-app' './pfs_image.dat'
-  python -m mkpfs pack file --verify './pfs_image.dat' './BREW1234.ffpfsc'
+  python -m mkpfs pack folder --no-compress --no-adjust-output-file-extension './BREW1234-app' './pfs_image.dat'
+  python -m mkpfs pack file './pfs_image.dat' './BREW1234.ffpfsc'
   rm './pfs_image.dat'
   
   # Creating Images: Option 4: Game folder without a wrapper (single-pass) (--no-compress) (Avoid; See Notes!)
-  python -m mkpfs pack folder --no-compress --verify './BREW1234-app/' './BREW1234.ffpfs'
+  python -m mkpfs pack folder --no-compress './BREW1234-app/' './BREW1234.ffpfs'
   
   # Extracting Existing Images (Reverse operation)
   python -m mkpfs unpack './BREW1234.ffpfs' './BREW1234-extracted/'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ help keep the CLI layer predictable and easy to maintain.
 - Do not mention you are an AI or attribute the text edits or anything to any AI tool like Claude or OpenClaude.
 - Never include generator or AI attribution lines in public-facing project text such as commit messages, PR titles,
   PR bodies, PR comments, release notes, changelog entries, or similar artifacts.
+- When using the `pr-writing` skill, do not stop at invoking it. You must make the final public text match the skill's structure and checklist before publishing or editing any commit, PR, comment, label, or tag.
 
 ## Agent / Tooling note
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ mkpfs pack folder [-h] [--adjust-output-file-extension | --no-adjust-output-file
                   [--min-compress-size MIN_COMPRESS_SIZE]
                   [--no-spool]
                   [--skip-executable-compression] [--signed] [--encrypted]
-                  [--ekpfs-key EKPFS_KEY] [--require-game-files] [--temp-folder TEMP_FOLDER] [--verbose] [--dry-run] [--verify]
+                  [--ekpfs-key EKPFS_KEY] [--require-game-files] [--temp-folder TEMP_FOLDER] [--verbose] [--dry-run] [--verify] [--verify-structure | --no-verify-structure] [--skip-verification]
                   source_dir image_file
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ MkPFS is designed to be a clean and practical entry point for PlayStation PFS im
 python -m pip install -U "mkpfs"
 
 # Creating Images: Option 1: .exfat -> .ffpfsc (Works with ShadowMountPlus)  (Maximum compatibility)
-python -m mkpfs pack file --verify './BREW1234.exfat' './BREW1234.ffpfsc'
+python -m mkpfs pack file './BREW1234.exfat' './BREW1234.ffpfsc'
 
 # Creating Images: Option 2: .ffpkg -> .ffpfsc (Works with ShadowMountPlus) 
-python -m mkpfs pack file --verify './BREW1234.ffpkg' './BREW1234.ffpfsc'
+python -m mkpfs pack file './BREW1234.ffpkg' './BREW1234.ffpfsc'
 
 # Creating Images: Option 3: Game folder wrapped twice into .ffpfsc (two-pass) (Works with ShadowMountPlus) 
-python -m mkpfs pack folder --verify --no-compress --no-adjust-output-file-extension './BREW1234-app' './pfs_image.dat'
-python -m mkpfs pack file --verify './pfs_image.dat' './BREW1234.ffpfsc'
+python -m mkpfs pack folder --no-compress --no-adjust-output-file-extension './BREW1234-app' './pfs_image.dat'
+python -m mkpfs pack file './pfs_image.dat' './BREW1234.ffpfsc'
 rm './pfs_image.dat'
 
 # Creating Images: Option 4: Game folder without a wrapper (single-pass) (--no-compress) (Avoid; See Notes!)
-python -m mkpfs pack folder --no-compress --verify './BREW1234-app/' './BREW1234.ffpfs'
+python -m mkpfs pack folder --no-compress './BREW1234-app/' './BREW1234.ffpfs'
 
 # Extracting Existing Images (Reverse operation)
 python -m mkpfs unpack './BREW1234.ffpfs' './BREW1234-extracted/'

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -12,6 +12,7 @@ import time
 from collections.abc import Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 
 from . import __version__, consts
@@ -48,6 +49,7 @@ from .pfs import (
     validate_input,
     validate_ps5_checklist,
     validate_source_match,
+    validate_source_paths,
     verify_file_payload_hashes,
     verify_signed_image_signatures,
 )
@@ -525,6 +527,8 @@ def run_image_check(
     new_crypt: bool = False,
     require_game_files: bool = False,
     verify_payloads: bool = True,
+    compare_source_contents: bool = True,
+    report_title: str = "PFS Check Report",
 ) -> tuple[list[str], list[str], dict[int, list[ParsedDirent]], int]:
     errors: list[str] = []
     warnings: list[str] = []
@@ -562,8 +566,8 @@ def run_image_check(
                 new_crypt=new_crypt,
             )
 
-            case_insensitive = bool(header.mode & consts.PFS_MODE_CASE_INSENSITIVE)
-            expected_fpt = build_expected_fpt(file_inodes, dir_inodes, case_insensitive)
+            case_insensitive: bool = bool(header.mode & consts.PFS_MODE_CASE_INSENSITIVE)
+            expected_fpt: dict[str, int] = build_expected_fpt(file_inodes, dir_inodes, case_insensitive)
             validate_fpt_maps(fpt_map, collision_map, expected_fpt, errors)
             # Payload-content passes (decode every file). Skipped for structure-only
             # callers such as the tree listing, which need only the directory layout.
@@ -604,8 +608,8 @@ def run_image_check(
                         f"expected {expected_manifest_sha256.lower()}"
                     )
 
-            reachable = set(file_inodes.values()) | set(dir_inodes.values()) | set(special_inodes)
-            orphan_inodes = sorted(i.number for i in inodes if i.number not in reachable)
+            reachable: set[int] = set(file_inodes.values()) | set(dir_inodes.values()) | set(special_inodes)
+            orphan_inodes: list[int] = sorted(i.number for i in inodes if i.number not in reachable)
             if orphan_inodes:
                 errors.append(
                     "orphan inodes not reachable from filesystem tree: "
@@ -614,21 +618,23 @@ def run_image_check(
                 )
 
             if source is not None:
-                validate_source_match(
-                    fh,
-                    header,
-                    inodes,
-                    file_inodes,
-                    source,
-                    errors,
-                    ekpfs=ekpfs,
-                    new_crypt=new_crypt,
-                    progress=progress,
-                )
+                validate_source_paths(file_inodes=file_inodes, source=source, errors=errors)
+                if compare_source_contents:
+                    validate_source_match(
+                        fh,
+                        header,
+                        inodes,
+                        file_inodes,
+                        source,
+                        errors,
+                        ekpfs=ekpfs,
+                        new_crypt=new_crypt,
+                        progress=progress,
+                    )
 
-            compressed_count = sum(1 for i in file_inodes.values() if inodes[i].is_compressed)
-            total_logical = sum(max(0, inodes[i].logical_size) for i in file_inodes.values())
-            total_stored = sum(max(0, inodes[i].stored_size) for i in file_inodes.values())
+            compressed_count: int = sum(1 for i in file_inodes.values() if inodes[i].is_compressed)
+            total_logical: int = sum(max(0, inodes[i].logical_size) for i in file_inodes.values())
+            total_stored: int = sum(max(0, inodes[i].stored_size) for i in file_inodes.values())
 
             # If verification is running interactively (emit_report) and the image
             # contains PS5 game markers (eboot.bin or sce_sys/param.json) while any
@@ -647,7 +653,7 @@ def run_image_check(
                 payload_magic: str = describe_magic(magic=consts.PFSC_MAGIC) if compressed_count > 0 else "none"
                 print_version_header()
                 info("=" * 70)
-                info("PFS Check Report")
+                info(report_title)
                 info("=" * 70)
                 info(f"Image:                 {image}")
                 ver_label: str = "PS5" if header.version == consts.PFS_VERSION_PS5 else "PS4"
@@ -797,7 +803,26 @@ def cli_mkpfs_add_create_args(
         )
     parser.add_argument("--verbose", action="store_true", help="Verbose per-file decisions")
     parser.add_argument("--dry-run", action="store_true", help="Scan/layout/report only; do not write image")
-    parser.add_argument("--verify", action="store_true", help="Run 'verify' after a successful pack")
+    parser.add_argument("--verify", action="store_true", help="Run full verification after a successful pack")
+    verify_structure_group = parser.add_mutually_exclusive_group()
+    verify_structure_group.add_argument(
+        "--verify-structure",
+        dest="verify_structure",
+        action="store_true",
+        default=True,
+        help="Run quick structure verification after a successful pack (default)",
+    )
+    verify_structure_group.add_argument(
+        "--no-verify-structure",
+        dest="verify_structure",
+        action="store_false",
+        help="Disable the default quick structure verification after a successful pack",
+    )
+    parser.add_argument(
+        "--skip-verification",
+        action="store_true",
+        help="Skip all post-pack verification",
+    )
 
 
 def _resolve_pack_temp_folder(args: argparse.Namespace) -> Path:
@@ -967,6 +992,43 @@ def _print_pack_parameters(
     )
 
 
+class PackVerificationMode(StrEnum):
+    """Supported post-pack verification modes."""
+
+    SKIP = "skip"
+    STRUCTURE = "structure"
+    FULL = "full"
+
+
+def _resolve_pack_verification_mode(args: argparse.Namespace) -> PackVerificationMode:
+    """Resolve the effective post-pack verification mode.
+
+    Args:
+        args: Parsed CLI arguments for a pack workflow.
+
+    Returns:
+        Effective post-pack verification mode.
+
+    Raises:
+        BuildError: If the verification flags are combined in an invalid way.
+    """
+    skip_verification: bool = bool(getattr(args, "skip_verification", False))
+    verify: bool = bool(getattr(args, "verify", False))
+    verify_structure: bool = bool(getattr(args, "verify_structure", True))
+
+    if skip_verification and verify:
+        raise BuildError("--verify and --skip-verification cannot be used together")
+    if skip_verification and verify_structure:
+        raise BuildError("--verify-structure and --skip-verification cannot be used together")
+    if skip_verification:
+        return PackVerificationMode.SKIP
+    if verify:
+        return PackVerificationMode.FULL
+    if verify_structure:
+        return PackVerificationMode.STRUCTURE
+    return PackVerificationMode.SKIP
+
+
 def _contains_direct_game_markers(root_path: Path) -> bool:
     """Return whether a source directory exposes direct PS5 game markers.
 
@@ -994,21 +1056,27 @@ def _run_post_pack_verify(
     source: Path,
     ekpfs_key: bytes,
     new_crypt: bool,
+    verification_mode: PackVerificationMode,
     require_game_files: bool = False,
 ) -> int:
-    """Run the post-pack image check and report warnings and errors.
+    """Run the selected post-pack image verification and report warnings and errors.
 
     Args:
         output_path: Written image to verify.
         source: Source directory compared against the image.
         ekpfs_key: EKPFS key material for encrypted images.
         new_crypt: Whether to use the alternate newCrypt derivation.
+        verification_mode: Effective post-pack verification mode.
         require_game_files: Whether to enable the optional game-file checklist.
 
     Returns:
         ``1`` when the check reports errors, otherwise ``0``.
     """
-    info("Running post-create check...")
+    verify_payloads: bool = verification_mode == PackVerificationMode.FULL
+    verification_label: str = "full verification" if verify_payloads else "structure verification"
+    compare_source_contents: bool = verification_mode != PackVerificationMode.STRUCTURE
+    report_title: str = "PFS Full Verify Report" if verify_payloads else "PFS Structure Verify Report"
+    info(f"Running post-pack {verification_label}...")
     errors, warnings, _tree, _uroot = run_image_check(
         output_path,
         source,
@@ -1016,6 +1084,9 @@ def _run_post_pack_verify(
         ekpfs=ekpfs_key,
         new_crypt=new_crypt,
         require_game_files=require_game_files,
+        verify_payloads=verify_payloads,
+        compare_source_contents=compare_source_contents,
+        report_title=report_title,
     )
     for w in warnings:
         warning(w, icon_name="warning")
@@ -1152,7 +1223,8 @@ def _run_pack_build(
 
     stats.input_path = display_source_path
     print_summary(stats)
-    if args.dry_run or not args.verify:
+    verification_mode: PackVerificationMode = _resolve_pack_verification_mode(args)
+    if args.dry_run or verification_mode == PackVerificationMode.SKIP:
         return 0
 
     return _run_post_pack_verify(
@@ -1160,6 +1232,7 @@ def _run_pack_build(
         source=compare_source_root,
         ekpfs_key=config.ekpfs_key,
         new_crypt=config.new_crypt,
+        verification_mode=verification_mode,
         require_game_files=require_game_files,
     )
 
@@ -1354,7 +1427,8 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
     )
     stats.input_path = source_file
     print_summary(stats)
-    if args.dry_run or not args.verify:
+    verification_mode: PackVerificationMode = _resolve_pack_verification_mode(args)
+    if args.dry_run or verification_mode == PackVerificationMode.SKIP:
         return 0
 
     # Stage the single file into a temp directory (hardlink, no data copy) so the
@@ -1369,6 +1443,7 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
             source=staging_root,
             ekpfs_key=config.ekpfs_key,
             new_crypt=config.new_crypt,
+            verification_mode=verification_mode,
         )
 
 

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -5157,6 +5157,39 @@ def validate_ps5_checklist(
         warnings.append("sce_sys/pfs-version.dat not found")
 
 
+def validate_source_paths(
+    *,
+    file_inodes: dict[str, int],
+    source: Path,
+    errors: list[str],
+) -> list[str] | None:
+    """Validate that the source tree and image expose the same file paths.
+
+    Args:
+        file_inodes: Mapping of relative image file paths to inode numbers.
+        source: Source directory used for comparison.
+        errors: Collected validation errors.
+
+    Returns:
+        Sorted list of relative file paths common to the source tree and image,
+        or ``None`` when the source directory is invalid.
+    """
+    if not source.exists() or not source.is_dir():
+        errors.append(f"source path does not exist or is not a directory: {source}")
+        return None
+
+    source_files: list[Path] = sorted(path for path in source.rglob("*") if path.is_file())
+    source_rel: set[str] = {path.relative_to(source).as_posix() for path in source_files}
+    image_rel: set[str] = set(file_inodes.keys())
+
+    for rel in sorted(source_rel - image_rel):
+        errors.append(f"missing in image: {rel}")
+    for rel in sorted(image_rel - source_rel):
+        errors.append(f"extra in image: {rel}")
+
+    return sorted(source_rel & image_rel)
+
+
 def validate_source_match(
     fh: BinaryIO,
     header: ParsedHeader,
@@ -5168,20 +5201,10 @@ def validate_source_match(
     new_crypt: bool = False,
     progress: Progress | None = None,
 ) -> None:
-    if not source.exists() or not source.is_dir():
-        errors.append(f"source path does not exist or is not a directory: {source}")
+    common: list[str] | None = validate_source_paths(file_inodes=file_inodes, source=source, errors=errors)
+    if common is None:
         return
 
-    source_files = sorted(p for p in source.rglob("*") if p.is_file())
-    source_rel = {p.relative_to(source).as_posix() for p in source_files}
-    image_rel = set(file_inodes.keys())
-
-    for rel in sorted(source_rel - image_rel):
-        errors.append(f"missing in image: {rel}")
-    for rel in sorted(image_rel - source_rel):
-        errors.append(f"extra in image: {rel}")
-
-    common = sorted(source_rel & image_rel)
     # Report progress against the total logical bytes to compare, throttled by volume.
     total_bytes: int = sum(max(0, inodes[file_inodes[rel]].logical_size) for rel in common)
     progress_total: int = max(total_bytes, 1)

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -85,6 +85,8 @@ class CliTestCase(unittest.TestCase):
             verbose=False,
             dry_run=dry_run,
             verify=verify,
+            verify_structure=True,
+            skip_verification=False,
         )
 
     def make_pack_file_args(
@@ -114,6 +116,8 @@ class CliTestCase(unittest.TestCase):
             verbose=False,
             dry_run=dry_run,
             verify=verify,
+            verify_structure=True,
+            skip_verification=False,
         )
 
 
@@ -166,6 +170,9 @@ class TestCliSmokeIntegration(CliTestCase):
         self.assertIn("source_dir", result.stdout)
         self.assertIn("image_file", result.stdout)
         self.assertIn("--require-game-files", result.stdout)
+        self.assertIn("--verify-structure", result.stdout)
+        self.assertIn("--no-verify-structure", result.stdout)
+        self.assertIn("--skip-verification", result.stdout)
 
         result = subprocess.run(
             [sys.executable, "-m", "mkpfs", "pack", "file", "--help"],
@@ -177,6 +184,9 @@ class TestCliSmokeIntegration(CliTestCase):
         self.assertIn(cli.get_help_title(), result.stdout)
         self.assertIn("source_file", result.stdout)
         self.assertIn("image_file", result.stdout)
+        self.assertIn("--verify-structure", result.stdout)
+        self.assertIn("--no-verify-structure", result.stdout)
+        self.assertIn("--skip-verification", result.stdout)
         self.assertNotIn("--require-game-files", result.stdout)
 
     def test_pack_file_defaults_to_32_bit_inodes_and_verify_source_file_succeeds(self) -> None:
@@ -482,6 +492,43 @@ class TestCliArgumentHelpers(CliTestCase):
         self.assertTrue(default_args.rename_inner_image)
         self.assertFalse(disabled_args.rename_inner_image)
         self.assertTrue(enabled_args.rename_inner_image)
+
+    def test_pack_parser_defaults_to_structure_verification(self) -> None:
+        """The pack parser should enable structure verification by default."""
+        parser: argparse.ArgumentParser = cli.cli_mkpfs_main_parsers()
+        parsed_args: argparse.Namespace = parser.parse_args(["pack", "folder", "src", "out.ffpfs"])
+        self.assertFalse(parsed_args.verify)
+        self.assertTrue(parsed_args.verify_structure)
+        self.assertFalse(parsed_args.skip_verification)
+
+    def test_pack_parser_parses_structure_verification_toggles(self) -> None:
+        """The pack parser should expose structure verification opt-in and opt-out flags."""
+        parser: argparse.ArgumentParser = cli.cli_mkpfs_main_parsers()
+        disabled_args: argparse.Namespace = parser.parse_args(
+            ["pack", "folder", "src", "out.ffpfs", "--no-verify-structure"]
+        )
+        enabled_args: argparse.Namespace = parser.parse_args(
+            ["pack", "folder", "src", "out.ffpfs", "--verify-structure"]
+        )
+        self.assertFalse(disabled_args.verify_structure)
+        self.assertTrue(enabled_args.verify_structure)
+
+    def test_resolve_pack_verification_mode_prefers_full_verify(self) -> None:
+        """Explicit full verification should override the default structure-only mode."""
+        args: argparse.Namespace = argparse.Namespace(verify=True, verify_structure=True, skip_verification=False)
+        self.assertEqual(cli._resolve_pack_verification_mode(args), cli.PackVerificationMode.FULL)
+
+    def test_resolve_pack_verification_mode_rejects_skip_with_full_verify(self) -> None:
+        """Skip verification should conflict with the full verify flag."""
+        args: argparse.Namespace = argparse.Namespace(verify=True, verify_structure=False, skip_verification=True)
+        with self.assertRaisesRegex(BuildError, "--verify and --skip-verification"):
+            cli._resolve_pack_verification_mode(args)
+
+    def test_resolve_pack_verification_mode_rejects_skip_with_structure_verify(self) -> None:
+        """Skip verification should conflict with structure verification when enabled."""
+        args: argparse.Namespace = argparse.Namespace(verify=False, verify_structure=True, skip_verification=True)
+        with self.assertRaisesRegex(BuildError, "--verify-structure and --skip-verification"):
+            cli._resolve_pack_verification_mode(args)
 
     def test_pack_parser_accepts_file_subcommand_with_output_positional(self) -> None:
         """The canonical pack file parser should keep source and output positional args."""
@@ -851,6 +898,7 @@ class TestCliCreateRun(CliTestCase):
             verify=False,
         )
         args.temp_folder = str(temp_folder)
+        args.verify_structure = False
         with patch.object(cli, "validate_input", return_value=("TITLE", [])), patch.object(
             cli,
             "prompt_overwrite",
@@ -1050,6 +1098,103 @@ class TestCliCreateRun(CliTestCase):
         self.assertIn("Use --temp-folder", stderr_buffer.getvalue())
         self.assertIn("Operation cancelled.", stderr_buffer.getvalue())
 
+    def test_create_run_defaults_to_structure_verification(self) -> None:
+        """Create run should perform structure verification by default after a real pack."""
+        tmp_path: Path = self.make_temp_path()
+        source_path: Path = self.make_valid_source(tmp_path)
+        output_path: Path = tmp_path / "out.ffpfs"
+        args: SimpleNamespace = self.make_create_args(
+            source_path=source_path,
+            image_path=output_path,
+            dry_run=False,
+            verify=False,
+        )
+
+        with patch.object(cli, "validate_input", return_value=("TITLE", [])), patch.object(
+            cli,
+            "prompt_overwrite",
+            return_value=True,
+        ), patch.object(
+            cli, "build_pfs", return_value=BuildStats(input_path=source_path, output_path=output_path)
+        ), patch.object(cli, "run_image_check", return_value=([], [], {}, -1)) as mocked_check:
+            self.assertEqual(cli.cli_mkpfs_create_run(args), 0)
+
+        self.assertFalse(mocked_check.call_args.kwargs["verify_payloads"])
+        self.assertFalse(mocked_check.call_args.kwargs["compare_source_contents"])
+        self.assertEqual(mocked_check.call_args.kwargs["report_title"], "PFS Structure Verify Report")
+
+    def test_create_run_skip_verification_disables_post_pack_check(self) -> None:
+        """Create run should skip post-pack verification when explicitly requested."""
+        tmp_path: Path = self.make_temp_path()
+        source_path: Path = self.make_valid_source(tmp_path)
+        output_path: Path = tmp_path / "out.ffpfs"
+        args: SimpleNamespace = self.make_create_args(
+            source_path=source_path,
+            image_path=output_path,
+            dry_run=False,
+            verify=False,
+        )
+        args.verify_structure = False
+        args.skip_verification = True
+
+        with patch.object(cli, "validate_input", return_value=("TITLE", [])), patch.object(
+            cli,
+            "prompt_overwrite",
+            return_value=True,
+        ), patch.object(
+            cli, "build_pfs", return_value=BuildStats(input_path=source_path, output_path=output_path)
+        ), patch.object(
+            cli,
+            "run_image_check",
+            side_effect=AssertionError("verify should not run"),
+        ):
+            self.assertEqual(cli.cli_mkpfs_create_run(args), 0)
+
+    def test_create_run_dry_run_skips_default_structure_verification(self) -> None:
+        """Create run dry-runs should not perform default structure verification."""
+        tmp_path: Path = self.make_temp_path()
+        source_path: Path = self.make_valid_source(tmp_path)
+        output_path: Path = tmp_path / "out.ffpfs"
+        args: SimpleNamespace = self.make_create_args(
+            source_path=source_path,
+            image_path=output_path,
+            dry_run=True,
+            verify=False,
+        )
+
+        with patch.object(cli, "validate_input", return_value=("TITLE", [])), patch.object(
+            cli,
+            "build_pfs",
+            return_value=BuildStats(input_path=source_path, output_path=output_path),
+        ), patch.object(
+            cli,
+            "run_image_check",
+            side_effect=AssertionError("verify should not run"),
+        ):
+            self.assertEqual(cli.cli_mkpfs_create_run(args), 0)
+
+    def test_create_run_verify_enables_full_post_pack_verification(self) -> None:
+        """Create run should upgrade to full verification when --verify is enabled."""
+        tmp_path: Path = self.make_temp_path()
+        source_path: Path = self.make_valid_source(tmp_path)
+        output_path: Path = tmp_path / "out.ffpfs"
+        args: SimpleNamespace = self.make_create_args(
+            source_path=source_path,
+            image_path=output_path,
+            dry_run=False,
+            verify=True,
+        )
+        stdout_buffer: StringIO = StringIO()
+
+        with patch.object(cli, "validate_input", return_value=("TITLE", [])), patch.object(
+            cli,
+            "prompt_overwrite",
+            return_value=True,
+        ), patch.object(
+            cli, "build_pfs", return_value=BuildStats(input_path=source_path, output_path=output_path)
+        ), patch.object(cli, "run_image_check", return_value=([], [], {}, -1)), redirect_stdout(stdout_buffer):
+            self.assertEqual(cli.cli_mkpfs_create_run(args), 0)
+
     def test_create_run_runs_post_verify_and_returns_error_when_check_fails(self) -> None:
         """Create run should perform post-verify and return a failure code when verification reports errors."""
         tmp_path: Path = self.make_temp_path()
@@ -1192,6 +1337,121 @@ class TestCliCreateRun(CliTestCase):
         ):
             self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
 
+    def test_pack_file_run_defaults_to_structure_verification(self) -> None:
+        """Pack file should perform structure verification by default after a real pack."""
+        tmp_path: Path = self.make_temp_path()
+        source_file: Path = tmp_path / "sample.bin"
+        source_file.write_bytes(b"payload")
+        output_path: Path = tmp_path / "out.ffpfsc"
+        args: SimpleNamespace = self.make_pack_file_args(
+            source_path=source_file,
+            image_path=output_path,
+            dry_run=False,
+            verify=False,
+        )
+
+        with patch.object(
+            cli,
+            "build_pfs_stream_single_file",
+            return_value=BuildStats(input_path=source_file, output_path=output_path),
+        ), patch.object(
+            cli,
+            "prompt_overwrite",
+            return_value=True,
+        ), patch.object(cli, "run_image_check", return_value=([], [], {}, -1)) as mocked_check:
+            self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
+
+        self.assertFalse(mocked_check.call_args.kwargs["verify_payloads"])
+        self.assertFalse(mocked_check.call_args.kwargs["compare_source_contents"])
+        self.assertEqual(mocked_check.call_args.kwargs["report_title"], "PFS Structure Verify Report")
+
+    def test_pack_file_run_skip_verification_disables_post_pack_check(self) -> None:
+        """Pack file should skip post-pack verification when explicitly requested."""
+        tmp_path: Path = self.make_temp_path()
+        source_file: Path = tmp_path / "sample.bin"
+        source_file.write_bytes(b"payload")
+        output_path: Path = tmp_path / "out.ffpfsc"
+        args: SimpleNamespace = self.make_pack_file_args(
+            source_path=source_file,
+            image_path=output_path,
+            dry_run=False,
+            verify=False,
+        )
+        args.verify_structure = False
+        args.skip_verification = True
+
+        with patch.object(
+            cli,
+            "build_pfs_stream_single_file",
+            return_value=BuildStats(input_path=source_file, output_path=output_path),
+        ), patch.object(
+            cli,
+            "prompt_overwrite",
+            return_value=True,
+        ), patch.object(
+            cli,
+            "run_image_check",
+            side_effect=AssertionError("verify should not run"),
+        ):
+            self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
+
+    def test_pack_file_run_dry_run_skips_default_structure_verification(self) -> None:
+        """Pack file dry-runs should not perform default structure verification."""
+        tmp_path: Path = self.make_temp_path()
+        source_file: Path = tmp_path / "sample.bin"
+        source_file.write_bytes(b"payload")
+        output_path: Path = tmp_path / "out.ffpfsc"
+        args: SimpleNamespace = self.make_pack_file_args(
+            source_path=source_file,
+            image_path=output_path,
+            dry_run=True,
+            verify=False,
+        )
+
+        with patch.object(
+            cli,
+            "build_pfs_stream_single_file",
+            return_value=BuildStats(input_path=source_file, output_path=output_path),
+        ), patch.object(
+            cli,
+            "run_image_check",
+            side_effect=AssertionError("verify should not run"),
+        ):
+            self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
+
+    def test_pack_file_run_verify_enables_full_post_pack_verification(self) -> None:
+        """Pack file should upgrade to full verification when --verify is enabled."""
+        tmp_path: Path = self.make_temp_path()
+        source_file: Path = tmp_path / "sample.bin"
+        source_file.write_bytes(b"payload")
+        output_path: Path = tmp_path / "out.ffpfsc"
+        args: SimpleNamespace = self.make_pack_file_args(
+            source_path=source_file,
+            image_path=output_path,
+            dry_run=False,
+            verify=True,
+        )
+        stdout_buffer: StringIO = StringIO()
+
+        with patch.object(
+            cli,
+            "build_pfs_stream_single_file",
+            return_value=BuildStats(input_path=source_file, output_path=output_path),
+        ), patch.object(
+            cli,
+            "prompt_overwrite",
+            return_value=True,
+        ), patch.object(cli, "run_image_check", return_value=([], [], {}, -1)) as mocked_check, redirect_stdout(
+            stdout_buffer
+        ):
+            self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
+
+        self.assertTrue(mocked_check.call_args.kwargs["verify_payloads"])
+        self.assertTrue(mocked_check.call_args.kwargs["compare_source_contents"])
+        self.assertEqual(mocked_check.call_args.kwargs["report_title"], "PFS Full Verify Report")
+        self.assertFalse(mocked_check.call_args.kwargs["require_game_files"])
+        self.assertIn("Running post-pack full verification...", stdout_buffer.getvalue())
+
     def test_pack_file_run_disables_game_file_checks_during_post_create_verify(self) -> None:
         """Pack file post-create verification should skip the optional game-file checklist."""
         tmp_path: Path = self.make_temp_path()
@@ -1218,8 +1478,6 @@ class TestCliCreateRun(CliTestCase):
 
         self.assertFalse(mocked_check.call_args.kwargs["require_game_files"])
 
-    def test_stage_single_file_source_root_copies_when_links_are_unavailable(self) -> None:
-        """Single-file staging should fall back to a regular copy when links are unavailable."""
         tmp_path: Path = self.make_temp_path()
         source_file: Path = tmp_path / "sample.bin"
         source_file.write_bytes(b"payload")
@@ -1748,6 +2006,7 @@ class TestRunImageCheck(CliTestCase):
             stack.enter_context(patch.object(cli, "validate_fpt_maps", return_value=None))
             stack.enter_context(patch.object(cli, "validate_ps5_checklist", return_value=None))
             stack.enter_context(patch.object(cli, "verify_file_payload_hashes", return_value=(1, 0x1234, "a" * 64)))
+            stack.enter_context(patch.object(cli, "validate_source_paths", return_value=["file.bin"]))
             stack.enter_context(patch.object(cli, "validate_source_match", return_value=None))
             stack.enter_context(patch.object(cli, "render_tree", return_value=["|- file.bin"]))
             errors, warnings, tree, uroot = cli.run_image_check(
@@ -1858,29 +2117,23 @@ class TestRunImageCheck(CliTestCase):
         self.assertEqual(uroot, 0)
         mocked_checklist.assert_called_once()
 
-    def test_run_image_check_reports_crc_manifest_and_orphan_mismatches(self) -> None:
-        """Image check should report checksum mismatches and orphan inodes when validation finds them."""
+    def test_run_image_check_path_only_mode_skips_content_reads(self) -> None:
+        """Structure checks should compare file paths without hashing payload contents."""
         tmp_path: Path = self.make_temp_path()
         image_path: Path = tmp_path / "image.ffpfs"
         image_path.write_bytes(b"x")
+        source_path: Path = tmp_path / "source"
+        source_path.mkdir()
         header: SimpleNamespace = SimpleNamespace(mode=0, version=0, magic=123, readonly=1, block_size=65536)
         inodes: list[SimpleNamespace] = [
             SimpleNamespace(
                 number=0,
                 is_compressed=False,
-                size=10,
-                size_compressed=10,
-                logical_size=10,
-                stored_size=10,
-            ),
-            SimpleNamespace(
-                number=99,
-                is_compressed=False,
-                size=10,
-                size_compressed=10,
-                logical_size=10,
-                stored_size=10,
-            ),
+                size=100,
+                size_compressed=90,
+                logical_size=100,
+                stored_size=90,
+            )
         ]
         with ExitStack() as stack:
             stack.enter_context(patch.object(cli, "parse_image_header", return_value=header))
@@ -1893,23 +2146,74 @@ class TestRunImageCheck(CliTestCase):
             )
             stack.enter_context(patch.object(cli, "build_expected_fpt", return_value={1: []}))
             stack.enter_context(patch.object(cli, "validate_fpt_maps", return_value=None))
-            stack.enter_context(patch.object(cli, "validate_ps5_checklist", return_value=None))
-            stack.enter_context(patch.object(cli, "verify_file_payload_hashes", return_value=(1, 0x1111, "b" * 64)))
-            errors, warnings, _tree, _uroot = cli.run_image_check(
+            mocked_paths = stack.enter_context(patch.object(cli, "validate_source_paths", return_value=["file.bin"]))
+            mocked_match = stack.enter_context(patch.object(cli, "validate_source_match", return_value=None))
+            mocked_hashes = stack.enter_context(
+                patch.object(cli, "verify_file_payload_hashes", return_value=(1, 0x1234, "a" * 64))
+            )
+            errors, warnings, tree, uroot = cli.run_image_check(
                 image=image_path,
-                source=None,
+                source=source_path,
                 print_tree=False,
-                expected_crc32=0x2222,
-                expected_manifest_sha256="a" * 64,
+                emit_report=False,
+                verify_payloads=False,
+                compare_source_contents=False,
+            )
+        self.assertEqual(errors, [])
+        self.assertEqual(warnings, [])
+        self.assertEqual(tree, {0: []})
+        self.assertEqual(uroot, 0)
+        mocked_paths.assert_called_once_with(file_inodes={"file.bin": 0}, source=source_path, errors=[])
+        mocked_match.assert_not_called()
+        mocked_hashes.assert_not_called()
+
+    def test_run_image_check_defaults_to_source_content_comparison(self) -> None:
+        """Full checks should keep source content comparison enabled by default."""
+        tmp_path: Path = self.make_temp_path()
+        image_path: Path = tmp_path / "image.ffpfs"
+        image_path.write_bytes(b"x")
+        source_path: Path = tmp_path / "source"
+        source_path.mkdir()
+        header: SimpleNamespace = SimpleNamespace(mode=0, version=0, magic=123, readonly=1, block_size=65536)
+        inodes: list[SimpleNamespace] = [
+            SimpleNamespace(
+                number=0,
+                is_compressed=False,
+                size=100,
+                size_compressed=90,
+                logical_size=100,
+                stored_size=90,
+            )
+        ]
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(cli, "parse_image_header", return_value=header))
+            stack.enter_context(patch.object(cli, "parse_image_inodes", return_value=inodes))
+            stack.enter_context(patch.object(cli, "validate_inode_layout", return_value=None))
+            stack.enter_context(patch.object(cli, "verify_signed_image_signatures", return_value=None))
+            stack.enter_context(patch.object(cli, "parse_superroot_and_indexes", return_value=(0, {1: 2}, {}, {0})))
+            stack.enter_context(
+                patch.object(cli, "build_tree_from_uroot", return_value=({"file.bin": 0}, {"": 0}, {0: []}))
+            )
+            stack.enter_context(patch.object(cli, "build_expected_fpt", return_value={1: []}))
+            stack.enter_context(patch.object(cli, "validate_fpt_maps", return_value=None))
+            stack.enter_context(patch.object(cli, "validate_source_paths", return_value=["file.bin"]))
+            mocked_match = stack.enter_context(patch.object(cli, "validate_source_match", return_value=None))
+            mocked_hashes = stack.enter_context(
+                patch.object(cli, "verify_file_payload_hashes", return_value=(1, 0x1234, "a" * 64))
+            )
+            errors, warnings, tree, uroot = cli.run_image_check(
+                image=image_path,
+                source=source_path,
+                print_tree=False,
                 emit_report=False,
             )
+        self.assertEqual(errors, [])
         self.assertEqual(warnings, [])
-        self.assertTrue(any("CRC32 mismatch" in item for item in errors))
-        self.assertTrue(any("Manifest SHA256 mismatch" in item for item in errors))
-        self.assertTrue(any("orphan inodes" in item for item in errors))
+        self.assertEqual(tree, {0: []})
+        self.assertEqual(uroot, 0)
+        mocked_hashes.assert_called_once()
+        mocked_match.assert_called_once()
 
-
-class TestCliPackFileNoSpool(CliTestCase):
     """Tests for the spool-free streaming flag on the file pack path."""
 
     def test_pack_file_stream_auto_block_size_defaults_min_compress_size_to_65536(self) -> None:


### PR DESCRIPTION
# Make post-pack verification much faster by default ✅

## Why? 🤔
- Packing already worked, but the default post-pack verification still read full file contents.
- That made the default verification slower than it needed to be, especially for large images.
- The goal here is to keep the default pack flow fast, while still preserving full verification when someone explicitly asks for it.

## What changed 🔧
- `pack folder` and `pack file` now use a fast structure-only verification by default after a successful non-dry-run build.
- The quick verification checks image structure and source paths without reading and hashing every file payload.
- `--verify` still upgrades the post-pack check to the full verification flow.
- `--skip-verification` still disables all post-pack verification.
- The README now documents the new pack verification flags.

## How to test 🧪
- Run `uv run --frozen pytest tests/mkpfs/test_cli.py -q`
- Run `./run-tests.sh`
- Manually compare `mkpfs pack folder ./input ./game.ffpfs` with `mkpfs pack folder ./input ./game.ffpfs --verify`

## Notes for non-technical readers 💬
- This change improves the default packing experience for large inputs.
- Full verification is still available when you want the slower, content-checking path.
- This does not change the standalone `verify` command semantics.