### PR TITLE
Stream pack output by default to reduce memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ mkpfs pack folder [-h] [--adjust-output-file-extension | --no-adjust-output-file
                   [--compression-level COMPRESSION_LEVEL]
                   [--max-compressed-ratio MAX_COMPRESSED_RATIO]
                   [--min-compress-size MIN_COMPRESS_SIZE]
-                  [--no-spool]
                   [--skip-executable-compression] [--signed] [--encrypted]
                   [--ekpfs-key EKPFS_KEY] [--require-game-files] [--temp-folder TEMP_FOLDER] [--verbose] [--dry-run] [--verify] [--verify-structure | --no-verify-structure] [--skip-verification]
                   source_dir image_file
@@ -208,7 +207,6 @@ mkpfs pack folder ./input ./game.ffpfs --temp-folder ./tmp/mkpfs
 | `--compression-level COMPRESSION_LEVEL` | Zlib compression level from `0` to `9`. Default: `7`. |
 | `--max-compressed-ratio MAX_COMPRESSED_RATIO` | Maximum PFSC size as percent of the raw file size. Use `95` to store files raw unless PFSC is 95% of raw size or smaller. Default: `95`. |
 | `--min-compress-size MIN_COMPRESS_SIZE` | Store files smaller than this many bytes raw without trying PFSC compression. When omitted (or set to `0`), MkPFS uses the resolved `--block-size` value, `65536` for `--block-size auto`, or the selected value for `--block-size auto-fit`. |
-| `--no-spool`                                  | Keep preferring direct-to-image streaming for single-file packing. This is already the default when supported; unsupported option combinations transparently fall back to the legacy staged/spool path. |
 | `--skip-executable-compression`               | Skip compression in important executable files. Default: enabled. |
 | `--signed`                                    | Build a signed PFS image using a zero EKPFS key and seed. |
 | `--encrypted`                                 | Encrypt filesystem blocks with AES-XTS. |
@@ -235,7 +233,7 @@ mkpfs pack file [-h] [--adjust-output-file-extension | --no-adjust-output-file-e
                 [--compression-level COMPRESSION_LEVEL]
                 [--max-compressed-ratio MAX_COMPRESSED_RATIO]
                 [--min-compress-size MIN_COMPRESS_SIZE]
-                [--no-spool]
+                [--use-spool]
                 [--skip-executable-compression] [--signed] [--encrypted]
                 [--ekpfs-key EKPFS_KEY] [--temp-folder TEMP_FOLDER] [--verbose] [--dry-run] [--verify]
                 source_file image_file
@@ -268,7 +266,7 @@ mkpfs pack file ./payload.exfat ./payload.ffpfsc --temp-folder ./tmp/mkpfs
 | `--compression-level COMPRESSION_LEVEL`       | Zlib compression level from `0` to `9`. Default: `7`.                                                                                                                                                   |
 | `--max-compressed-ratio MAX_COMPRESSED_RATIO` | Maximum PFSC size as percent of the raw file size. Use `95` to store files raw unless PFSC is 95% of raw size or smaller. Default: `95`.                                                                 |
 | `--min-compress-size MIN_COMPRESS_SIZE`       | Store files smaller than this many bytes raw without trying PFSC compression. When omitted (or set to `0`), MkPFS uses the resolved `--block-size` value, `65536` for `--block-size auto`, or the selected value for `--block-size auto-fit`.                                              |
-| `--no-spool`                                  | Keep preferring direct-to-image streaming for single-file packing. This is already the default when supported; unsupported option combinations transparently fall back to the legacy staged/spool path. |
+| `--use-spool`                                 | Force the legacy staged/spool builder for single-file packing instead of the default direct-to-image streaming. |
 | `--skip-executable-compression`               | Skip compression in important executable files. Default: enabled.                                                                                            |
 | `--signed`                                    | Build a signed PFS image using a zero EKPFS key and seed.                                                                                                                                               |
 | `--encrypted`                                 | Encrypt filesystem blocks with AES-XTS.                                                                                                                                                                 |
@@ -282,7 +280,8 @@ Notes:
 
 - `pack file` now uses the direct-to-image streaming builder by default for supported option combinations. It
   automatically falls back to the legacy staged/spool path for `--signed`, `--inode-bits 64`, and
-  `--block-size auto-fit`.
+  `--block-size auto-fit`, printing a short notice that explains the reason.
+- Use `--use-spool` to force the legacy staged/spool builder even when streaming is supported.
 - Single-file fallback mode stages the file in a temporary one-file tree using links, so the source payload is not
   duplicated on disk.
 - Use `--temp-folder` when you want fallback staged files and any legacy PFSC spool files to live somewhere other than

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -839,21 +839,24 @@ def _resolve_pack_temp_folder(args: argparse.Namespace) -> Path:
     return resolve_temp_root(temp_folder=temp_folder)
 
 
-def _can_stream_pack_file(*, args: argparse.Namespace) -> bool:
-    """Return whether single-file packing can use the streaming builder.
+def _stream_fallback_reason(*, args: argparse.Namespace) -> str | None:
+    """Return why single-file streaming is unavailable, or None when supported.
 
     Args:
         args: Parsed CLI arguments for the single-file pack workflow.
 
     Returns:
-        True when the streaming builder supports the requested options.
+        A human-readable reason the streaming builder cannot be used, or ``None``
+        when the requested options are supported by streaming.
     """
+    if bool(getattr(args, "signed", False)):
+        return "signed images"
+    if int(getattr(args, "inode_bits", 32)) != 32:
+        return "64-bit inodes"
     block_size_arg: str = str(getattr(args, "block_size", "")).strip().lower()
-    return not (
-        bool(getattr(args, "signed", False))
-        or int(getattr(args, "inode_bits", 32)) != 32
-        or block_size_arg in {"auto-fit", "auto_small_files", "auto-small-files"}
-    )
+    if block_size_arg in {"auto-fit", "auto_small_files", "auto-small-files"}:
+        return "auto-fit block size"
+    return None
 
 
 @dataclass(frozen=True)
@@ -1356,7 +1359,7 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
     if output_changed:
         info("Single file streaming mode enabled, adjusting output file extension to .ffpfsc")
 
-    # Resolve block size (single-file path: auto or explicit, no auto-fit).
+    # Resolve block size (single-file path: auto or explicit; auto-fit routes to the spool path).
     block_size_arg: str = str(args.block_size).strip().lower() if isinstance(args.block_size, str) else ""
     if block_size_arg in {"auto-fit", "auto_small_files", "auto-small-files"}:
         raise BuildError(
@@ -1465,13 +1468,20 @@ def cli_mkpfs_pack_file_run(args: argparse.Namespace) -> int:
         source_file=source_file,
         rename_inner_image=rename_inner_image,
     )
-    if rename_inner_image and internal_file_name != source_file.name and not _can_stream_pack_file(args=args):
+    if (
+        rename_inner_image
+        and internal_file_name != source_file.name
+        and _stream_fallback_reason(args=args) is not None
+    ):
         _emit_single_file_rename_warning(original_name=source_file.name, renamed_name=internal_file_name)
 
-    # Prefer direct streaming for the common single-file path, fall back to the
-    # legacy staged/spool builder only when the requested options require it.
-    if _can_stream_pack_file(args=args):
+    # Prefer direct-to-image streaming for the common single-file path; fall back to
+    # the legacy staged/spool builder only when forced or when options require it.
+    reason: str | None = _stream_fallback_reason(args=args)
+    if not getattr(args, "use_spool", False) and reason is None:
         return _run_stream_pack_file(args=args, source_file=source_file)
+    if not getattr(args, "use_spool", False) and reason is not None:
+        info(f"Direct-to-image streaming unavailable ({reason}); using the spool builder.")
 
     with _stage_single_file_source_root(
         source_file=source_file,
@@ -1784,11 +1794,11 @@ def cli_mkpfs_main_parsers() -> argparse.ArgumentParser:
         include_require_game_files=False,
     )
     file_parser.add_argument(
-        "--no-spool",
+        "--use-spool",
         action="store_true",
         help=(
-            "Prefer direct-to-image streaming for single-file packing; this is already the default when supported, "
-            "and unsupported option combinations fall back to the legacy spool path"
+            "Force the legacy staged/spool builder for single-file packing instead of the default "
+            "direct-to-image streaming"
         ),
     )
     file_parser.add_argument(

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -112,6 +112,7 @@ class CliTestCase(unittest.TestCase):
             signed=False,
             encrypted=False,
             ekpfs_key=None,
+            use_spool=False,
             rename_inner_image=True,
             verbose=False,
             dry_run=dry_run,
@@ -1522,7 +1523,7 @@ class TestCliCreateRun(CliTestCase):
             verify=False,
         )
         with patch.object(cli, "_run_stream_pack_file", return_value=0), patch.object(
-            cli, "_can_stream_pack_file", return_value=False
+            cli, "_stream_fallback_reason", return_value="signed images"
         ), patch.object(cli, "warning") as mocked_warning:
             self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
 
@@ -2241,14 +2242,13 @@ class TestRunImageCheck(CliTestCase):
         out: Path = tmp_path / "payload.ffpfsc"
         args: SimpleNamespace = self.make_pack_file_args(source_path=src, image_path=out, dry_run=True, verify=False)
         args.block_size = "auto-fit"
-        args.no_spool = True
         with patch.object(cli, "build_pfs", return_value=self.make_build_stats(tmp_path)) as mocked_build:
             self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
         resolved_block_size: int = mocked_build.call_args.kwargs["block_size"]
         self.assertEqual(mocked_build.call_args.kwargs["min_compress_size"], resolved_block_size)
 
-    def test_pack_file_no_spool_creates_image_without_spool(self) -> None:
-        """`pack file --no-spool` writes the image and leaves no spool in the temp folder."""
+    def test_pack_file_streams_by_default_without_spool(self) -> None:
+        """`pack file` streams by default and leaves no spool in the temp folder."""
         tmp_path: Path = self.make_temp_path()
         src: Path = tmp_path / "PPSA.exfat"
         src.write_bytes(b"DATA" * 20000 + b"\x00" * 60000)
@@ -2269,7 +2269,6 @@ class TestRunImageCheck(CliTestCase):
                     "PS5",
                     "--inode-bits",
                     "32",
-                    "--no-spool",
                     "--temp-folder",
                     str(temp),
                     "--no-adjust-output-file-extension",
@@ -2279,15 +2278,14 @@ class TestRunImageCheck(CliTestCase):
         self.assertTrue(out.exists())
         self.assertEqual(list(temp.glob("mkpfs-*.pfsc")), [])
 
-    def test_pack_file_no_spool_falls_back_for_signed(self) -> None:
-        """Combining --no-spool with --signed should fall back to the legacy builder."""
+    def test_pack_file_use_spool_forces_legacy_builder(self) -> None:
+        """`--use-spool` forces the legacy staged/spool builder even when streaming is supported."""
         tmp_path: Path = self.make_temp_path()
         src: Path = tmp_path / "x.exfat"
         src.write_bytes(b"x" * 1000)
         out: Path = tmp_path / "x.ffpfsc"
         args: SimpleNamespace = self.make_pack_file_args(source_path=src, image_path=out, dry_run=True, verify=False)
-        args.no_spool = True
-        args.signed = True
+        args.use_spool = True
         with patch.object(
             cli, "_run_stream_pack_file", side_effect=AssertionError("streaming should not run")
         ), patch.object(
@@ -2298,14 +2296,30 @@ class TestRunImageCheck(CliTestCase):
             self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
         mocked_pack.assert_called_once()
 
-    def test_pack_folder_does_not_accept_no_spool(self) -> None:
-        """The --no-spool flag is only available on the file path, not the folder path."""
+    def test_pack_file_falls_back_for_signed_with_notice(self) -> None:
+        """`--signed` falls back to the legacy builder and prints a notice."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "x.exfat"
+        src.write_bytes(b"x" * 1000)
+        out: Path = tmp_path / "x.ffpfsc"
+        args: SimpleNamespace = self.make_pack_file_args(source_path=src, image_path=out, dry_run=True, verify=False)
+        args.signed = True
+        buffer: StringIO = StringIO()
+        with patch.object(
+            cli, "_run_stream_pack_file", side_effect=AssertionError("streaming should not run")
+        ), patch.object(cli, "_run_pack_build", return_value=0) as mocked_pack, redirect_stdout(buffer):
+            self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
+        mocked_pack.assert_called_once()
+        self.assertIn("signed images", buffer.getvalue())
+
+    def test_pack_folder_does_not_accept_use_spool(self) -> None:
+        """The --use-spool flag is only available on the file path, not the folder path."""
         parser: argparse.ArgumentParser = cli.cli_mkpfs_main_parsers()
         with self.assertRaises(SystemExit):
-            parser.parse_args(["pack", "folder", "src", "out", "--no-spool"])
+            parser.parse_args(["pack", "folder", "src", "out", "--use-spool"])
 
-    def test_pack_file_no_spool_with_verify_succeeds(self) -> None:
-        """`pack file --no-spool --verify` completes the post-create check without errors."""
+    def test_pack_file_streaming_with_verify_succeeds(self) -> None:
+        """`pack file --verify` completes the post-create check without errors."""
         tmp_path: Path = self.make_temp_path()
         src: Path = tmp_path / "PPSA.exfat"
         src.write_bytes(b"GAMEDATA" * 20000 + b"\x00" * 200000)
@@ -2324,7 +2338,6 @@ class TestRunImageCheck(CliTestCase):
                     "PS5",
                     "--inode-bits",
                     "32",
-                    "--no-spool",
                     "--verify",
                     "--temp-folder",
                     str(tmp_path / "temp"),
@@ -2333,7 +2346,7 @@ class TestRunImageCheck(CliTestCase):
             )
         self.assertEqual(rc, 0)
 
-    def test_pack_file_no_spool_prints_parameters_and_progress(self) -> None:
+    def test_pack_file_streaming_prints_parameters_and_progress(self) -> None:
         """The streaming path prints the parameters banner and a compression status line."""
         tmp_path: Path = self.make_temp_path()
         src: Path = tmp_path / "PPSA.exfat"
@@ -2354,7 +2367,6 @@ class TestRunImageCheck(CliTestCase):
                     "PS5",
                     "--inode-bits",
                     "32",
-                    "--no-spool",
                     "--temp-folder",
                     str(tmp_path / "temp"),
                     "--no-adjust-output-file-extension",
@@ -2366,14 +2378,13 @@ class TestRunImageCheck(CliTestCase):
         self.assertIn("Source path:", combined)
         self.assertIn("Compressing 1 file", combined)
 
-    def test_pack_file_no_spool_falls_back_for_inode_bits_64(self) -> None:
-        """64-bit inode requests should fall back to the legacy single-file builder."""
+    def test_pack_file_falls_back_for_inode_bits_64(self) -> None:
+        """64-bit inode requests fall back to the legacy single-file builder."""
         tmp_path: Path = self.make_temp_path()
         src: Path = tmp_path / "x.exfat"
         src.write_bytes(b"x" * 1000)
         out: Path = tmp_path / "x.ffpfsc"
         args: SimpleNamespace = self.make_pack_file_args(source_path=src, image_path=out, dry_run=True, verify=False)
-        args.no_spool = True
         args.inode_bits = 64
         with patch.object(
             cli, "_run_stream_pack_file", side_effect=AssertionError("streaming should not run")
@@ -2385,14 +2396,13 @@ class TestRunImageCheck(CliTestCase):
             self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
         mocked_pack.assert_called_once()
 
-    def test_pack_file_no_spool_falls_back_for_auto_fit_block_size(self) -> None:
-        """Auto-fit block size requests should fall back to the legacy single-file builder."""
+    def test_pack_file_falls_back_for_auto_fit_block_size(self) -> None:
+        """Auto-fit block size requests fall back to the legacy single-file builder."""
         tmp_path: Path = self.make_temp_path()
         src: Path = tmp_path / "x.exfat"
         src.write_bytes(b"x" * 1000)
         out: Path = tmp_path / "x.ffpfsc"
         args: SimpleNamespace = self.make_pack_file_args(source_path=src, image_path=out, dry_run=True, verify=False)
-        args.no_spool = True
         args.block_size = "auto-fit"
         with patch.object(
             cli, "_run_stream_pack_file", side_effect=AssertionError("streaming should not run")
@@ -2404,8 +2414,8 @@ class TestRunImageCheck(CliTestCase):
             self.assertEqual(cli.cli_mkpfs_pack_file_run(args), 0)
         mocked_pack.assert_called_once()
 
-    def test_pack_file_no_spool_dry_run_writes_nothing(self) -> None:
-        """--no-spool --dry-run reports layout without writing an image."""
+    def test_pack_file_streaming_dry_run_writes_nothing(self) -> None:
+        """`pack file --dry-run` reports layout without writing an image."""
         tmp_path: Path = self.make_temp_path()
         src: Path = tmp_path / "PPSA.exfat"
         src.write_bytes(b"DATA" * 20000 + b"\x00" * 60000)
@@ -2415,7 +2425,7 @@ class TestRunImageCheck(CliTestCase):
             StringIO()
         ):
             rc: int = cli_mkpfs_main(
-                ["pack", "file", str(src), str(out), "--no-spool", "--dry-run", "--no-adjust-output-file-extension"]
+                ["pack", "file", str(src), str(out), "--dry-run", "--no-adjust-output-file-extension"]
             )
         self.assertEqual(rc, 0)
         self.assertFalse(out.exists())

--- a/uv.lock
+++ b/uv.lock
@@ -1953,19 +1953,35 @@ name = "readme-renderer"
 version = "44.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
     "python_full_version > '3.9' and python_full_version < '3.10'",
     "python_full_version == '3.9' and platform_python_implementation != 'PyPy'",
     "python_full_version == '3.9' and platform_python_implementation == 'PyPy'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "nh3", marker = "python_full_version >= '3.9'" },
-    { name = "pygments", version = "2.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "docutils", version = "0.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "nh3", marker = "python_full_version == '3.9.*'" },
+    { name = "pygments", version = "2.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz", hash = "sha256:8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1", size = 32056, upload-time = "2024-07-08T15:00:57.805Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl", hash = "sha256:2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151", size = 13310, upload-time = "2024-07-08T15:00:56.577Z" },
+]
+
+[[package]]
+name = "readme-renderer"
+version = "45.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "docutils", version = "0.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "nh3", marker = "python_full_version >= '3.10'" },
+    { name = "pygments", version = "2.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/51/d3a6ea424652c60f05600d8c2e01a55c913755e7cdad64afabbd1aa16f44/readme_renderer-45.0.tar.gz", hash = "sha256:030a8fac74904f8fba11ad1bb6964e3f76e896dc7e5e71f16af190c9056696d1", size = 36172, upload-time = "2026-06-09T21:05:17.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/1b/295bf2fa3e740131778065e5ffa2c481f0e7210182d408e9a2c244ff5b0c/readme_renderer-45.0-py3-none-any.whl", hash = "sha256:3385ed220117104a2bceb4a9dac8c5fdf6d1f96890d7ea2a9c7174fd5c84091f", size = 14134, upload-time = "2026-06-09T21:05:15.85Z" },
 ]
 
 [[package]]
@@ -2241,7 +2257,8 @@ dependencies = [
     { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "keyring", version = "25.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and platform_machine != 'ppc64le' and platform_machine != 's390x'" },
     { name = "packaging", marker = "python_full_version >= '3.9'" },
-    { name = "readme-renderer", version = "44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "readme-renderer", version = "44.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "readme-renderer", version = "45.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "requests-toolbelt", marker = "python_full_version >= '3.9'" },


### PR DESCRIPTION
# Summary
- Stream pack output by default for lower memory use and faster feedback.
- Add a --use-spool flag to opt out of streaming and fall back to spool-based packing.
- Show a clear notice when spool fallback occurs.

## Motivation / Context
Users packing large inputs can run into high memory usage and delayed feedback when the entire pack is spooled before writing. Streaming the pack file by default reduces peak memory, speeds up perceived progress, and avoids unnecessary temporary spool files. The --use-spool flag preserves the previous behavior for environments that require it.

## What changed
- CLI: pack subcommand now streams output by default.
- New flag: `--use-spool` to force spool-based packing (opt-out of streaming).
- User-visible notice: when a spool fallback occurs, the CLI prints a short warning with guidance.
- Internal: pack implementation refactored to support both streaming and spool paths without changing other command surfaces.
- Tests: added/updated unit and integration tests covering streaming and spool modes.

## Test plan
Run the project checks and tests locally:

1. Activate the local venv:
   - source .venv/bin/activate
2. Install dev deps (if needed):
   - uv sync --group dev
3. Run formatting and tests:
   - ./run-tests.sh
   - uv run --frozen ruff check .
   - uv run --frozen pytest
4. Manual smoke test:
   - mkpfs pack --path ./tests/fixtures/sample_dir --output ./tmp/sample.pfs  # verify streaming output appears
   - mkpfs pack --path ./tests/fixtures/sample_dir --output ./tmp/sample-spool.pfs --use-spool  # verify spool path and spool notice
5. Build artifacts for packaging validation:
   - uv build
   - uv run --frozen twine check dist/*

## Checklist
- [ ] uv run --frozen ruff check . passes
- [ ] uv run --frozen pytest passes (all new and existing tests)
- [ ] ./run-tests.sh completes successfully
- [ ] Package builds and `uv run --frozen twine check dist/*` passes
- [ ] Confirm CLI help text and README examples remain accurate

## Release notes
Stream pack output by default to reduce memory usage and improve feedback; add --use-spool flag to restore spool behavior.

## Suggested reviewers / labels
- Reviewers: @maintainers, @psbrew/core
- Labels: feature, cli, performance