### PR TITLE
Add --no-progress opt-out for extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ mkpfs tree ./game.ffpfs
 ### `unpack`
 
 ```text
-mkpfs unpack [-h] [--overwrite] [--ekpfs-key EKPFS_KEY] [--new-crypt] image_file output_dir
+mkpfs unpack [-h] [--overwrite] [--ekpfs-key EKPFS_KEY] [--new-crypt] [--no-progress] image_file output_dir
 ```
 
 Examples:
@@ -384,6 +384,7 @@ mkpfs unpack ./game.ffpfs ./extracted/ --overwrite
 | `--overwrite` | Overwrite an existing output path. |
 | `--ekpfs-key EKPFS_KEY` | Optional 64-hex EKPFS key for encrypted images. |
 | `--new-crypt` | Use the alternate `newCrypt` EKPFS derivation. |
+| `--no-progress` | Disable the extraction progress bar on stderr. |
 
 
 ## 💻 Example Output

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -1780,11 +1780,15 @@ def cli_mkpfs_extract_run(args: argparse.Namespace) -> int:
         info(f"output path {output_path} exists (use --overwrite to force)")
         return 2
 
+    # Stream extraction progress to stderr unless the caller opted out. The
+    # extract loop reports a per-file "extract" phase with byte throughput.
+    progress: Progress = Progress(enabled=not bool(getattr(args, "no_progress", False)))
+
     # Perform extraction via library API
     result: PFSExtractionResult = extract_pfs_image(
         image=image,
         output_path=output_path,
-        progress=None,
+        progress=progress,
         ekpfs=parse_ekpfs_key_hex(getattr(args, "ekpfs_key", None)),
         new_crypt=bool(getattr(args, "new_crypt", False)),
     )
@@ -1910,6 +1914,9 @@ def cli_mkpfs_main_parsers() -> argparse.ArgumentParser:
     extract_parser.add_argument("--overwrite", action="store_true", help="Overwrite existing output path")
     extract_parser.add_argument("--ekpfs-key", help="Optional 64-hex EKPFS key for encrypted images")
     extract_parser.add_argument("--new-crypt", action="store_true", help="Use alternate newCrypt EKPFS derivation")
+    extract_parser.add_argument(
+        "--no-progress", action="store_true", help="Disable the extraction progress bar on stderr"
+    )
     extract_parser.set_defaults(func=cli_mkpfs_extract_run)
 
     return parser

--- a/mkpfs/pfs.py
+++ b/mkpfs/pfs.py
@@ -5276,7 +5276,7 @@ class PFSImageInfo(PFSOperationResult):
 
     @property
     def version_label(self) -> str:
-        """Return the human-friendly version label."""
+        """The human-friendly version label."""
         if self.header is None:
             return ""
         return "PS5" if self.header.version == consts.PFS_VERSION_PS5 else "PS4"
@@ -5325,7 +5325,7 @@ class PFSImageInspection(PFSImageInfo):
 
     @property
     def has_tree(self) -> bool:
-        """Return whether the inspection contains a parsed filesystem tree."""
+        """Whether the inspection contains a parsed filesystem tree."""
         return self.uroot_inode >= 0 and len(self.dirents_by_inode) > 0
 
 

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -755,6 +755,33 @@ class TestCliOutputFormatting(CliTestCase):
         self.assertIn(cli.get_output_title(), output_text)
         self.assertIn("Extraction complete:", output_text)
 
+    def test_extract_run_disables_progress_with_no_progress_flag(self) -> None:
+        """The --no-progress flag should yield a disabled Progress reporter."""
+        extraction_result: PFSExtractionResult = PFSExtractionResult(
+            image=Path("img.ffpfs"),
+            output_path=Path("out"),
+        )
+        stdout_buffer: StringIO = StringIO()
+        with (
+            patch.object(cli, "extract_pfs_image", return_value=extraction_result) as mocked_extract,
+            redirect_stdout(stdout_buffer),
+        ):
+            exit_code: int = cli.cli_mkpfs_extract_run(
+                SimpleNamespace(
+                    image_file="img.ffpfs",
+                    output_dir="out",
+                    overwrite=True,
+                    ekpfs_key=None,
+                    new_crypt=False,
+                    no_progress=True,
+                )
+            )
+
+        self.assertEqual(exit_code, 0)
+        passed_progress: cli.Progress = mocked_extract.call_args.kwargs["progress"]
+        self.assertIsInstance(passed_progress, cli.Progress)
+        self.assertFalse(passed_progress.enabled)
+
 
 class TestCliCreateRun(CliTestCase):
     """Tests for pack command execution and validation branches."""


### PR DESCRIPTION
## Summary

Originally this PR wired the unpack progress bar, but #62 already covers that (plus perf wins). I've **rescoped it down to the one thing #62 doesn't have**: a way to turn the extraction progress bar *off*.

Adds a `--no-progress` flag to `unpack` so the bar can be silenced for non-interactive use — scripts, CI, or piping output to a file. The flag gates the `Progress` reporter's `enabled` state.

## Changes
- `mkpfs/cli.py`: add `--no-progress` to the `unpack` parser; gate the progress reporter on it.
- `tests/mkpfs/test_cli.py`: regression test for the disabled (`--no-progress`) path.
- `README.md`: document the flag in the `unpack` section.

## Relationship to #62
This touches the same `progress=` line as #62, so it'll show a one-line conflict once #62 merges. The resolution is trivial (keep the flag-gated form, a strict superset of `enabled=True`). **I'll rebase onto main as soon as #62 lands.** Happy to fold the flag into #62 instead if that's cleaner for you.

## Testing
- `./run-tests.sh` — ruff format + check clean, full suite passes.
- Manual: `mkpfs unpack` shows the bar by default; `--no-progress` keeps stderr silent; extracted output is byte-identical.