### PR TITLE
feat: add --no-progress to replace bars with simple messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ uv build
 uv run --frozen twine check dist/*
 ```
 
+## Progress output
+
+By default MkPFS shows interactive progress bars for long-running phases (scan, compress, write, verify, extract).
+When you prefer concise logs (for CI or simple terminals), pass --no-progress on supported commands to replace the
+bars with short, one-line status messages like:
+
+  Discovering files...
+  Compressing files...
+
+Supported commands: pack (folder/file/exfat), verify, and unpack.
+
 ## Command Reference
 
 MkPFS keeps the command surface focused on the image lifecycle. 
@@ -363,6 +374,7 @@ mkpfs verify ./BREW1234.exfat --source-dir ./BREW1234-app --format exfat
 | `--ekpfs-key EKPFS_KEY` | Optional 64-hex EKPFS key for encrypted images. |
 | `--new-crypt` | Use the alternate `newCrypt` EKPFS derivation. |
 | `--format {auto,pfs,exfat}` | Image format hint. `auto` (default) detects exFAT by extension/signature and treats everything else as PFS; `pfs` forces PFS handling; `exfat` forces exFAT handling. |
+| `--no-progress` | Replace interactive progress bars with simple one-line status messages. |
 
 ### `inspect`
 
@@ -436,6 +448,7 @@ mkpfs unpack ./BREW1234.exfat ./BREW1234-extracted/ --format exfat
 | `--ekpfs-key EKPFS_KEY` | Optional 64-hex EKPFS key for encrypted images. |
 | `--new-crypt` | Use the alternate `newCrypt` EKPFS derivation. |
 | `--format {auto,pfs,exfat}` | Image format hint. `auto` (default) detects exFAT by extension/signature and treats everything else as PFS; `pfs` forces PFS handling; `exfat` forces exFAT handling. |
+| `--no-progress` | Replace interactive progress bars with simple one-line status messages. |
 
 
 ## 💻 Example Output

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -20,7 +20,7 @@ from .ampr import ensure_ampr_index
 from .exfat import EXFAT_SIGNATURE, ExfatReader, render_exfat_tree
 from .exfat_writer import iter_exfat_image, write_exfat_image
 from .logging import error, info, warning
-from .pbar import Progress
+from .pbar import Progress, set_progress_style
 from .pfs import (
     BuildError,
     BuildStats,
@@ -733,6 +733,12 @@ def cli_mkpfs_add_create_args(
     parser.add_argument(source_arg_name, help=source_help)
     parser.add_argument("image_file", help="Output image file path")
 
+    parser.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Replace interactive progress bars with simple one-line status messages",
+    )
+
     adjust_group = parser.add_mutually_exclusive_group()
     adjust_group.add_argument(
         "--adjust-output-file-extension",
@@ -1341,41 +1347,53 @@ def cli_mkpfs_pack_exfat_run(args: argparse.Namespace) -> int:
     Returns:
         Process exit code for the exFAT packing workflow.
     """
-    source: Path = Path(args.source_dir).expanduser().resolve()
-    if not source.is_dir():
-        raise BuildError(f"source must be an existing directory: {source}")
+    reset_needed: bool = bool(getattr(args, "no_progress", False))
+    if reset_needed:
+        from .pbar import get_progress_style
 
-    cluster_arg: str = str(args.cluster_size).strip().lower()
-    cluster_size: int | None
-    if cluster_arg in {"auto", ""}:
-        cluster_size = None
+        prev_style: str = get_progress_style()
+        set_progress_style("simple")
     else:
-        try:
-            cluster_size = int(args.cluster_size)
-        except (TypeError, ValueError) as exc:
-            raise BuildError("--cluster-size must be an integer or 'auto'") from exc
-        if not is_power_of_two(cluster_size) or cluster_size < 512 or cluster_size > 32 * 1024 * 1024:
-            raise BuildError("--cluster-size must be a power of two between 512 and 33554432")
+        prev_style = "bar"
+    try:
+        source: Path = Path(args.source_dir).expanduser().resolve()
+        if not source.is_dir():
+            raise BuildError(f"source must be an existing directory: {source}")
 
-    # Resolve the final output path so we can pre-check overwrite and report it.
-    basename: str = f"{default_image_basename(source)}.exfat"
-    if args.output is None:
-        target: Path = source.parent / basename
-    else:
-        requested: Path = Path(args.output).expanduser().resolve()
-        target = requested / basename if requested.is_dir() else requested
+        cluster_arg: str = str(args.cluster_size).strip().lower()
+        cluster_size: int | None
+        if cluster_arg in {"auto", ""}:
+            cluster_size = None
+        else:
+            try:
+                cluster_size = int(args.cluster_size)
+            except (TypeError, ValueError) as exc:
+                raise BuildError("--cluster-size must be an integer or 'auto'") from exc
+            if not is_power_of_two(cluster_size) or cluster_size < 512 or cluster_size > 32 * 1024 * 1024:
+                raise BuildError("--cluster-size must be a power of two between 512 and 33554432")
 
-    if target.exists() and not args.overwrite:
-        error(f"output already exists (use --overwrite): {target}")
-        return 1
-    target.parent.mkdir(parents=True, exist_ok=True)
+        # Resolve the final output path so we can pre-check overwrite and report it.
+        basename: str = f"{default_image_basename(source)}.exfat"
+        if args.output is None:
+            target: Path = source.parent / basename
+        else:
+            requested: Path = Path(args.output).expanduser().resolve()
+            target = requested / basename if requested.is_dir() else requested
 
-    print_version_header()
-    info(f"Building exFAT image from {source}")
-    info(f"  Output: {target}")
-    written: Path = write_exfat_image(source, target, cluster_size=cluster_size, progress=Progress(enabled=True))
-    info(f"Successfully wrote {human_readable_size(written.stat().st_size)} exFAT image: {written}")
-    return 0
+        if target.exists() and not args.overwrite:
+            error(f"output already exists (use --overwrite): {target}")
+            return 1
+        target.parent.mkdir(parents=True, exist_ok=True)
+
+        print_version_header()
+        info(f"Building exFAT image from {source}")
+        info(f"  Output: {target}")
+        written: Path = write_exfat_image(source, target, cluster_size=cluster_size, progress=Progress(enabled=True))
+        info(f"Successfully wrote {human_readable_size(written.stat().st_size)} exFAT image: {written}")
+        return 0
+    finally:
+        if reset_needed:
+            set_progress_style(prev_style)
 
 
 def _run_exfat_pack(*, args: argparse.Namespace, source_path: Path) -> int:
@@ -1388,72 +1406,84 @@ def _run_exfat_pack(*, args: argparse.Namespace, source_path: Path) -> int:
     Returns:
         Process exit code.
     """
-    output_path, output_changed = normalize_output_path(
-        args.image_file, ".ffpfsc", adjust=bool(getattr(args, "adjust_output_file_extension", True))
-    )
-    output_path = output_path.expanduser().resolve()
-    if output_changed:
-        info("exFAT wrapping mode enabled, adjusting output file extension to .ffpfsc")
+    reset_needed: bool = bool(getattr(args, "no_progress", False))
+    if reset_needed:
+        from .pbar import get_progress_style
 
-    if args.signed:
-        raise BuildError("--exfat wrapping does not support --signed images")
-
-    config: PackBuildConfig = _resolve_pack_build_config(args, block_size=65536)
-    temp_folder: Path = _resolve_pack_temp_folder(args)
-    _print_pack_parameters(
-        config=config,
-        display_source_path=source_path,
-        output_path=output_path,
-        temp_folder=temp_folder,
-        signed=False,
-        require_game_files=False,
-        dry_run=args.dry_run,
-    )
-
-    if args.dry_run:
-        size_box: list[int] = []
-        blocks = iter_exfat_image(source_path, on_layout=size_box.append)
-        try:
-            next(blocks)  # trigger the scan + layout to learn the inner exFAT size
-        finally:
-            blocks.close()
-        info(
-            f"Dry run: would wrap {source_path} into a {human_readable_size(size_box[0])} "
-            f"exFAT and compress it to {output_path}; nothing written."
+        prev_style: str = get_progress_style()
+        set_progress_style("simple")
+    else:
+        prev_style = "bar"
+    try:
+        output_path, output_changed = normalize_output_path(
+            args.image_file, ".ffpfsc", adjust=bool(getattr(args, "adjust_output_file_extension", True))
         )
-        return 0
-    if not prompt_overwrite(output_path):
-        info("Operation cancelled.")
-        return 0
+        output_path = output_path.expanduser().resolve()
+        if output_changed:
+            info("exFAT wrapping mode enabled, adjusting output file extension to .ffpfsc")
 
-    stats: BuildStats = build_pfs_stream_from_exfat(
-        source_root=source_path,
-        output_path=output_path,
-        block_size=config.block_size,
-        pfs_version=config.pfs_version,
-        case_insensitive=config.case_insensitive,
-        zlib_level=config.zlib_level,
-        threshold_gain=config.threshold_gain,
-        cpu_count=config.cpu_count,
-        encrypted=config.encrypted,
-        new_crypt=config.new_crypt,
-        ekpfs=config.ekpfs_key,
-        verbose=args.verbose,
-    )
-    stats.input_path = source_path
-    print_summary(stats)
-    if not args.verify:
-        return 0
+        if args.signed:
+            raise BuildError("--exfat wrapping does not support --signed images")
 
-    info("Running post-create check...")
-    errors, warnings, _tree, _uroot = run_image_check(
-        output_path, None, print_tree=False, ekpfs=config.ekpfs_key, new_crypt=config.new_crypt
-    )
-    for w in warnings:
-        warning(w)
-    for e in errors:
-        error(e)
-    return 1 if errors else 0
+        config: PackBuildConfig = _resolve_pack_build_config(args, block_size=65536)
+        temp_folder: Path = _resolve_pack_temp_folder(args)
+        _print_pack_parameters(
+            config=config,
+            display_source_path=source_path,
+            output_path=output_path,
+            temp_folder=temp_folder,
+            signed=False,
+            require_game_files=False,
+            dry_run=args.dry_run,
+        )
+
+        if args.dry_run:
+            size_box: list[int] = []
+            blocks = iter_exfat_image(source_path, on_layout=size_box.append)
+            try:
+                next(blocks)  # trigger the scan + layout to learn the inner exFAT size
+            finally:
+                blocks.close()
+            info(
+                f"Dry run: would wrap {source_path} into a {human_readable_size(size_box[0])} "
+                f"exFAT and compress it to {output_path}; nothing written."
+            )
+            return 0
+        if not prompt_overwrite(output_path):
+            info("Operation cancelled.")
+            return 0
+
+        stats: BuildStats = build_pfs_stream_from_exfat(
+            source_root=source_path,
+            output_path=output_path,
+            block_size=config.block_size,
+            pfs_version=config.pfs_version,
+            case_insensitive=config.case_insensitive,
+            zlib_level=config.zlib_level,
+            threshold_gain=config.threshold_gain,
+            cpu_count=config.cpu_count,
+            encrypted=config.encrypted,
+            new_crypt=config.new_crypt,
+            ekpfs=config.ekpfs_key,
+            verbose=args.verbose,
+        )
+        stats.input_path = source_path
+        print_summary(stats)
+        if not args.verify:
+            return 0
+
+        info("Running post-create check...")
+        errors, warnings, _tree, _uroot = run_image_check(
+            output_path, None, print_tree=False, ekpfs=config.ekpfs_key, new_crypt=config.new_crypt
+        )
+        for w in warnings:
+            warning(w)
+        for e in errors:
+            error(e)
+        return 1 if errors else 0
+    finally:
+        if reset_needed:
+            set_progress_style(prev_style)
 
 
 def cli_mkpfs_create_run(args: argparse.Namespace) -> int:
@@ -1465,40 +1495,52 @@ def cli_mkpfs_create_run(args: argparse.Namespace) -> int:
     Returns:
         Process exit code for the folder packing workflow.
     """
-    source_path: Path = Path(args.source_dir).expanduser().resolve()
-    temp_folder: Path = _resolve_pack_temp_folder(args)
-    # Generate the AMPR emulation index into the source tree before packing so it
-    # is included in the image (only when an emulation build marker is present).
-    if not args.dry_run:
-        ensure_ampr_index(source_path, enabled=bool(getattr(args, "ampr_index", True)))
+    reset_needed: bool = bool(getattr(args, "no_progress", False))
+    if reset_needed:
+        from .pbar import get_progress_style
 
-    # Default: wrap the folder in an exFAT and compress it into the .ffpfsc in one
-    # pass, with no temporary .exfat. Use --raw to pack the folder directly as PFS.
-    if not bool(getattr(args, "raw", False)):
-        return _run_exfat_pack(args=args, source_path=source_path)
-
-    title_id: str | None = _detect_title_id_from_source(source_path)
-    desired_output_suffix: str = ".ffpfs" if title_id is not None else ".ffpfsc"
-    output_adjustment_message: str
-    if title_id is not None:
-        output_adjustment_message = (
-            "Raw game files detected inside the source folder, adjusting output file extension to .ffpfs"
-        )
+        prev_style: str = get_progress_style()
+        set_progress_style("simple")
     else:
-        output_adjustment_message = (
-            "The folder does not seem to contain any direct game information, "
-            "adjusting output file extension to .ffpfsc"
+        prev_style = "bar"
+    try:
+        source_path: Path = Path(args.source_dir).expanduser().resolve()
+        temp_folder: Path = _resolve_pack_temp_folder(args)
+        # Generate the AMPR emulation index into the source tree before packing so it
+        # is included in the image (only when an emulation build marker is present).
+        if not args.dry_run:
+            ensure_ampr_index(source_path, enabled=bool(getattr(args, "ampr_index", True)))
+
+        # Default: wrap the folder in an exFAT and compress it into the .ffpfsc in one
+        # pass, with no temporary .exfat. Use --raw to pack the folder directly as PFS.
+        if not bool(getattr(args, "raw", False)):
+            return _run_exfat_pack(args=args, source_path=source_path)
+
+        title_id: str | None = _detect_title_id_from_source(source_path)
+        desired_output_suffix: str = ".ffpfs" if title_id is not None else ".ffpfsc"
+        output_adjustment_message: str
+        if title_id is not None:
+            output_adjustment_message = (
+                "Raw game files detected inside the source folder, adjusting output file extension to .ffpfs"
+            )
+        else:
+            output_adjustment_message = (
+                "The folder does not seem to contain any direct game information, "
+                "adjusting output file extension to .ffpfsc"
+            )
+        return _run_pack_build(
+            args=args,
+            build_source_root=source_path,
+            compare_source_root=source_path,
+            display_source_path=source_path,
+            temp_folder=temp_folder,
+            require_game_files=bool(getattr(args, "require_game_files", False)),
+            desired_output_suffix=desired_output_suffix,
+            output_adjustment_message=output_adjustment_message,
         )
-    return _run_pack_build(
-        args=args,
-        build_source_root=source_path,
-        compare_source_root=source_path,
-        display_source_path=source_path,
-        temp_folder=temp_folder,
-        require_game_files=bool(getattr(args, "require_game_files", False)),
-        desired_output_suffix=desired_output_suffix,
-        output_adjustment_message=output_adjustment_message,
-    )
+    finally:
+        if reset_needed:
+            set_progress_style(prev_style)
 
 
 def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int:
@@ -1514,110 +1556,122 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
     Raises:
         BuildError: If CLI parameters are invalid.
     """
-    output_path: Path
-    output_changed: bool
-    output_path, output_changed = normalize_output_path(
-        args.image_file,
-        ".ffpfsc",
-        adjust=bool(getattr(args, "adjust_output_file_extension", True)),
-    )
-    output_path = output_path.expanduser().resolve()
-    if output_changed:
-        info("Single file streaming mode enabled, adjusting output file extension to .ffpfsc")
+    reset_needed: bool = bool(getattr(args, "no_progress", False))
+    if reset_needed:
+        from .pbar import get_progress_style
 
-    # Resolve block size (single-file path: auto or explicit; auto-fit routes to the spool path).
-    block_size_arg: str = str(args.block_size).strip().lower() if isinstance(args.block_size, str) else ""
-    if block_size_arg in {"auto-fit", "auto_small_files", "auto-small-files"}:
-        raise BuildError(
-            "--block-size auto-fit is not supported for single-file packing; use 'auto' or an explicit size"
-        )
-    if block_size_arg in {"auto", ""}:
-        block_size: int = 65536
+        prev_style: str = get_progress_style()
+        set_progress_style("simple")
     else:
-        try:
-            block_size = int(args.block_size)
-        except (TypeError, ValueError) as exc:
+        prev_style = "bar"
+    try:
+        output_path: Path
+        output_changed: bool
+        output_path, output_changed = normalize_output_path(
+            args.image_file,
+            ".ffpfsc",
+            adjust=bool(getattr(args, "adjust_output_file_extension", True)),
+        )
+        output_path = output_path.expanduser().resolve()
+        if output_changed:
+            info("Single file streaming mode enabled, adjusting output file extension to .ffpfsc")
+
+        # Resolve block size (single-file path: auto or explicit; auto-fit routes to the spool path).
+        block_size_arg: str = str(args.block_size).strip().lower() if isinstance(args.block_size, str) else ""
+        if block_size_arg in {"auto-fit", "auto_small_files", "auto-small-files"}:
             raise BuildError(
-                "--block-size must be an integer value or 'auto' for streaming single-file packing"
-            ) from exc
+                "--block-size auto-fit is not supported for single-file packing; use 'auto' or an explicit size"
+            )
+        if block_size_arg in {"auto", ""}:
+            block_size: int = 65536
+        else:
+            try:
+                block_size = int(args.block_size)
+            except (TypeError, ValueError) as exc:
+                raise BuildError(
+                    "--block-size must be an integer value or 'auto' for streaming single-file packing"
+                ) from exc
 
-    config: PackBuildConfig = _resolve_pack_build_config(args, block_size=block_size)
-    temp_folder: Path = _resolve_pack_temp_folder(args)
-    rename_inner_image: bool = bool(getattr(args, "rename_inner_image", True))
-    internal_file_name: str = _resolve_single_file_internal_name(
-        source_file=source_file,
-        rename_inner_image=rename_inner_image,
-    )
-    if rename_inner_image and internal_file_name != source_file.name:
-        _emit_single_file_rename_warning(original_name=source_file.name, renamed_name=internal_file_name)
-
-    _print_pack_parameters(
-        config=config,
-        display_source_path=source_file,
-        output_path=output_path,
-        temp_folder=temp_folder,
-        signed=False,
-        require_game_files=False,
-        dry_run=args.dry_run,
-    )
-
-    if not args.dry_run:
-        destination_space_error: str | None = get_destination_space_error_message(
-            source_root=source_file,
-            output_path=output_path,
+        config: PackBuildConfig = _resolve_pack_build_config(args, block_size=block_size)
+        temp_folder: Path = _resolve_pack_temp_folder(args)
+        rename_inner_image: bool = bool(getattr(args, "rename_inner_image", True))
+        internal_file_name: str = _resolve_single_file_internal_name(
+            source_file=source_file,
+            rename_inner_image=rename_inner_image,
         )
-        if destination_space_error is not None:
-            error(destination_space_error, icon_name="error")
-            return 1
+        if rename_inner_image and internal_file_name != source_file.name:
+            _emit_single_file_rename_warning(original_name=source_file.name, renamed_name=internal_file_name)
 
-    if not args.dry_run and not prompt_overwrite(output_path):
-        info("Operation cancelled.")
-        return 0
-
-    stats: BuildStats = build_pfs_stream_single_file(
-        source_file=source_file,
-        output_path=output_path,
-        block_size=config.block_size,
-        pfs_version=config.pfs_version,
-        case_insensitive=config.case_insensitive,
-        zlib_level=config.zlib_level,
-        threshold_gain=config.threshold_gain,
-        min_file_gain=config.min_file_gain,
-        min_compress_size=config.min_compress_size,
-        cpu_count=config.cpu_count,
-        compress=config.compress,
-        encrypted=config.encrypted,
-        new_crypt=config.new_crypt,
-        ekpfs=config.ekpfs_key,
-        verbose=args.verbose,
-        skip_executable_compression=config.skip_executable_compression,
-        dry_run=args.dry_run,
-        inner_file_name=internal_file_name,
-    )
-    stats.input_path = source_file
-    print_summary(stats)
-    verification_mode: PackVerificationMode = _resolve_pack_verification_mode(args)
-    if args.dry_run or verification_mode == PackVerificationMode.SKIP:
-        return 0
-
-    # Stage the single file into a temp directory (hardlink, no data copy) so the
-    # check compares against a directory tree, mirroring the verify command.
-    with _stage_single_file_source_root(
-        source_file=source_file,
-        temp_folder=temp_folder,
-        staged_file_name=internal_file_name,
-    ) as staging_root:
-        rc: int = _run_post_pack_verify(
+        _print_pack_parameters(
+            config=config,
+            display_source_path=source_file,
             output_path=output_path,
-            source=staging_root,
-            ekpfs_key=config.ekpfs_key,
+            temp_folder=temp_folder,
+            signed=False,
+            require_game_files=False,
+            dry_run=args.dry_run,
+        )
+
+        if not args.dry_run:
+            destination_space_error: str | None = get_destination_space_error_message(
+                source_root=source_file,
+                output_path=output_path,
+            )
+            if destination_space_error is not None:
+                error(destination_space_error, icon_name="error")
+                return 1
+
+        if not args.dry_run and not prompt_overwrite(output_path):
+            info("Operation cancelled.")
+            return 0
+
+        stats: BuildStats = build_pfs_stream_single_file(
+            source_file=source_file,
+            output_path=output_path,
+            block_size=config.block_size,
+            pfs_version=config.pfs_version,
+            case_insensitive=config.case_insensitive,
+            zlib_level=config.zlib_level,
+            threshold_gain=config.threshold_gain,
+            min_file_gain=config.min_file_gain,
+            min_compress_size=config.min_compress_size,
+            cpu_count=config.cpu_count,
+            compress=config.compress,
+            encrypted=config.encrypted,
             new_crypt=config.new_crypt,
-            verification_mode=verification_mode,
-            hide_headers=True,
+            ekpfs=config.ekpfs_key,
+            verbose=args.verbose,
+            skip_executable_compression=config.skip_executable_compression,
+            dry_run=args.dry_run,
+            inner_file_name=internal_file_name,
         )
-        if rc == 0:
-            info("🎉 Image created successfully!")
-        return rc
+        stats.input_path = source_file
+        print_summary(stats)
+        verification_mode: PackVerificationMode = _resolve_pack_verification_mode(args)
+        if args.dry_run or verification_mode == PackVerificationMode.SKIP:
+            return 0
+
+        # Stage the single file into a temp directory (hardlink, no data copy) so the
+        # check compares against a directory tree, mirroring the verify command.
+        with _stage_single_file_source_root(
+            source_file=source_file,
+            temp_folder=temp_folder,
+            staged_file_name=internal_file_name,
+        ) as staging_root:
+            rc: int = _run_post_pack_verify(
+                output_path=output_path,
+                source=staging_root,
+                ekpfs_key=config.ekpfs_key,
+                new_crypt=config.new_crypt,
+                verification_mode=verification_mode,
+                hide_headers=True,
+            )
+            if rc == 0:
+                info("🎉 Image created successfully!")
+            return rc
+    finally:
+        if reset_needed:
+            set_progress_style(prev_style)
 
 
 def cli_mkpfs_pack_file_run(args: argparse.Namespace) -> int:
@@ -1629,108 +1683,134 @@ def cli_mkpfs_pack_file_run(args: argparse.Namespace) -> int:
     Returns:
         Process exit code for the file packing workflow.
     """
-    source_file: Path = Path(args.source_file).expanduser().resolve()
-    temp_folder: Path = _resolve_pack_temp_folder(args)
-    rename_inner_image: bool = bool(getattr(args, "rename_inner_image", True))
-    if not source_file.exists() or not source_file.is_file():
-        raise BuildError(f"--source-file must be an existing file: {source_file}")
-    internal_file_name: str = _resolve_single_file_internal_name(
-        source_file=source_file,
-        rename_inner_image=rename_inner_image,
-    )
-    if (
-        rename_inner_image
-        and internal_file_name != source_file.name
-        and _stream_fallback_reason(args=args) is not None
-    ):
-        _emit_single_file_rename_warning(original_name=source_file.name, renamed_name=internal_file_name)
+    reset_needed: bool = bool(getattr(args, "no_progress", False))
+    if reset_needed:
+        from .pbar import get_progress_style
 
-    # Prefer direct-to-image streaming for the common single-file path; fall back to
-    # the legacy staged/spool builder only when forced or when options require it.
-    reason: str | None = _stream_fallback_reason(args=args)
-    if not getattr(args, "use_spool", False) and reason is None:
-        return _run_stream_pack_file(args=args, source_file=source_file)
-    if not getattr(args, "use_spool", False) and reason is not None:
-        info(f"Direct-to-image streaming unavailable ({reason}); using the spool builder.")
-
-    with _stage_single_file_source_root(
-        source_file=source_file,
-        temp_folder=temp_folder,
-        staged_file_name=internal_file_name,
-    ) as staging_root:
-        return _run_pack_build(
-            args=args,
-            build_source_root=staging_root,
-            compare_source_root=staging_root,
-            display_source_path=source_file,
-            temp_folder=temp_folder,
-            require_game_files=False,
-            desired_output_suffix=".ffpfsc",
-            output_adjustment_message=(
-                "Single file compression mode enabled, adjusting output file extension "
-                "to match the container mode .ffpfsc"
-            ),
+        prev_style: str = get_progress_style()
+        set_progress_style("simple")
+    else:
+        prev_style = "bar"
+    try:
+        source_file: Path = Path(args.source_file).expanduser().resolve()
+        temp_folder: Path = _resolve_pack_temp_folder(args)
+        rename_inner_image: bool = bool(getattr(args, "rename_inner_image", True))
+        if not source_file.exists() or not source_file.is_file():
+            raise BuildError(f"--source-file must be an existing file: {source_file}")
+        internal_file_name: str = _resolve_single_file_internal_name(
+            source_file=source_file,
+            rename_inner_image=rename_inner_image,
         )
+        if (
+            rename_inner_image
+            and internal_file_name != source_file.name
+            and _stream_fallback_reason(args=args) is not None
+        ):
+            _emit_single_file_rename_warning(original_name=source_file.name, renamed_name=internal_file_name)
+
+        # Prefer direct-to-image streaming for the common single-file path; fall back to
+        # the legacy staged/spool builder only when forced or when options require it.
+        reason: str | None = _stream_fallback_reason(args=args)
+        if not getattr(args, "use_spool", False) and reason is None:
+            return _run_stream_pack_file(args=args, source_file=source_file)
+        if not getattr(args, "use_spool", False) and reason is not None:
+            info(f"Direct-to-image streaming unavailable ({reason}); using the spool builder.")
+
+        with _stage_single_file_source_root(
+            source_file=source_file,
+            temp_folder=temp_folder,
+            staged_file_name=internal_file_name,
+        ) as staging_root:
+            return _run_pack_build(
+                args=args,
+                build_source_root=staging_root,
+                compare_source_root=staging_root,
+                display_source_path=source_file,
+                temp_folder=temp_folder,
+                require_game_files=False,
+                desired_output_suffix=".ffpfsc",
+                output_adjustment_message=(
+                    "Single file compression mode enabled, adjusting output file extension "
+                    "to match the container mode .ffpfsc"
+                ),
+            )
+    finally:
+        if reset_needed:
+            set_progress_style(prev_style)
 
 
 def cli_mkpfs_check_run(args: argparse.Namespace) -> int:
-    image: Path = Path(args.image_file).expanduser().resolve()
-    source_dir_arg: str | None = getattr(args, "source_dir", None)
-    source_file_arg: str | None = getattr(args, "source_file", None)
-    if source_dir_arg and source_file_arg:
-        info("--source-dir and --source-file cannot be used together")
-        return 2
+    reset_needed: bool = bool(getattr(args, "no_progress", False))
+    if reset_needed:
+        from .pbar import get_progress_style
 
-    fmt_text: str = getattr(args, "format", "auto")
-    fmt: ImageFormat = ImageFormat(fmt_text)
-    detected: ImageFormat = detect_image_format(image=image, hint=fmt)
-
-    # Raw exFAT verify path.
-    if detected == ImageFormat.EXFAT:
-        if source_file_arg:
-            info("--source-file is not supported for exFAT verify; use --source-dir")
+        prev_style: str = get_progress_style()
+        set_progress_style("simple")
+    else:
+        prev_style = "bar"
+    try:
+        image: Path = Path(args.image_file).expanduser().resolve()
+        source_dir_arg: str | None = getattr(args, "source_dir", None)
+        source_file_arg: str | None = getattr(args, "source_file", None)
+        if source_dir_arg and source_file_arg:
+            info("--source-dir and --source-file cannot be used together")
             return 2
-        source: Path | None = Path(source_dir_arg).expanduser().resolve() if source_dir_arg else None
-        errors, warnings = verify_exfat_image(image=image, source=source, compare_contents=source is not None)
-        for w in warnings:
-            warning(w, icon_name="warning")
-        for e in errors:
-            error(e, icon_name="error")
-        return 1 if errors else 0
 
-    # Default PFS verify path (existing behaviour).
-    source: Path | None = None
-    if source_dir_arg:
-        source = Path(source_dir_arg).expanduser().resolve()
-    elif source_file_arg:
-        source_file: Path = Path(source_file_arg).expanduser().resolve()
-        if not source_file.exists() or not source_file.is_file():
-            info(f"--source-file must be an existing file: {source_file}")
-            return 2
-        internal_file_name: str = _resolve_single_file_internal_name(source_file=source_file, rename_inner_image=True)
-        if internal_file_name != source_file.name:
-            _emit_single_file_verify_name_mismatch_warning(
-                external_name=source_file.name,
-                internal_name=internal_file_name,
-            )
-        with _stage_single_file_source_root(
-            source_file=source_file,
-            staged_file_name=internal_file_name,
-        ) as staging_root:
-            source = staging_root
-            return _run_verify_check(
-                image=image,
-                source=source,
-                args=args,
-                require_game_files=bool(getattr(args, "require_game_files", False)),
-            )
+        fmt_text: str = getattr(args, "format", "auto")
+        fmt: ImageFormat = ImageFormat(fmt_text)
+        detected: ImageFormat = detect_image_format(image=image, hint=fmt)
 
-    return _run_verify_check(
-        image=image,
-        source=source,
-        args=args,
-        require_game_files=bool(getattr(args, "require_game_files", False)),
-    )
+        # Raw exFAT verify path.
+        if detected == ImageFormat.EXFAT:
+            if source_file_arg:
+                info("--source-file is not supported for exFAT verify; use --source-dir")
+                return 2
+            source: Path | None = Path(source_dir_arg).expanduser().resolve() if source_dir_arg else None
+            errors, warnings = verify_exfat_image(image=image, source=source, compare_contents=source is not None)
+            for w in warnings:
+                warning(w, icon_name="warning")
+            for e in errors:
+                error(e, icon_name="error")
+            return 1 if errors else 0
+
+        # Default PFS verify path (existing behaviour).
+        source: Path | None = None
+        if source_dir_arg:
+            source = Path(source_dir_arg).expanduser().resolve()
+        elif source_file_arg:
+            source_file: Path = Path(source_file_arg).expanduser().resolve()
+            if not source_file.exists() or not source_file.is_file():
+                info(f"--source-file must be an existing file: {source_file}")
+                return 2
+            internal_file_name: str = _resolve_single_file_internal_name(
+                source_file=source_file, rename_inner_image=True
+            )
+            if internal_file_name != source_file.name:
+                _emit_single_file_verify_name_mismatch_warning(
+                    external_name=source_file.name,
+                    internal_name=internal_file_name,
+                )
+            with _stage_single_file_source_root(
+                source_file=source_file,
+                staged_file_name=internal_file_name,
+            ) as staging_root:
+                source = staging_root
+                return _run_verify_check(
+                    image=image,
+                    source=source,
+                    args=args,
+                    require_game_files=bool(getattr(args, "require_game_files", False)),
+                )
+
+        return _run_verify_check(
+            image=image,
+            source=source,
+            args=args,
+            require_game_files=bool(getattr(args, "require_game_files", False)),
+        )
+    finally:
+        if reset_needed:
+            set_progress_style(prev_style)
 
 
 def _run_verify_check(
@@ -1948,34 +2028,70 @@ def cli_mkpfs_analyze_run(args: argparse.Namespace) -> int:
 
 def cli_mkpfs_extract_run(args: argparse.Namespace) -> int:
     """Extract all files from an image into a directory."""
-    image: Path = Path(args.image_file).expanduser().resolve()
-    output_path: Path = Path(args.output_dir).expanduser().resolve()
-    deep: bool = bool(getattr(args, "deep", False))
-    selectors: list[str] | None = getattr(args, "only", None)
+    reset_needed: bool = bool(getattr(args, "no_progress", False))
+    if reset_needed:
+        from .pbar import get_progress_style
 
-    if selectors and not deep:
-        info("--only requires --deep (it selects entries inside the wrapped exFAT)")
-        return 2
+        prev_style: str = get_progress_style()
+        set_progress_style("simple")
+    else:
+        prev_style = "bar"
+    try:
+        image: Path = Path(args.image_file).expanduser().resolve()
+        output_path: Path = Path(args.output_dir).expanduser().resolve()
+        deep: bool = bool(getattr(args, "deep", False))
+        selectors: list[str] | None = getattr(args, "only", None)
 
-    if output_path.exists() and not args.overwrite:
-        info(f"output path {output_path} exists (use --overwrite to force)")
-        return 2
+        if selectors and not deep:
+            info("--only requires --deep (it selects entries inside the wrapped exFAT)")
+            return 2
 
-    fmt_text: str = getattr(args, "format", "auto")
-    fmt: ImageFormat = ImageFormat(fmt_text)
-    detected: ImageFormat = detect_image_format(image=image, hint=fmt)
+        if output_path.exists() and not args.overwrite:
+            info(f"output path {output_path} exists (use --overwrite to force)")
+            return 2
 
-    # Raw exFAT unpack path.
-    if detected == ImageFormat.EXFAT:
-        if deep:
-            info("--deep has no effect for raw exFAT images; extracting image contents")
-        if selectors:
-            info("--only is not supported for raw exFAT images; extracting everything")
-        result: PFSExtractionResult = extract_exfat_image(
+        fmt_text: str = getattr(args, "format", "auto")
+        fmt: ImageFormat = ImageFormat(fmt_text)
+        detected: ImageFormat = detect_image_format(image=image, hint=fmt)
+
+        # Raw exFAT unpack path.
+        if detected == ImageFormat.EXFAT:
+            if deep:
+                info("--deep has no effect for raw exFAT images; extracting image contents")
+            if selectors:
+                info("--only is not supported for raw exFAT images; extracting everything")
+            result: PFSExtractionResult = extract_exfat_image(
+                image=image,
+                output_path=output_path,
+                progress=Progress(enabled=True),
+            )
+            for w in result.warnings:
+                info(w)
+            for e in result.errors:
+                info(e)
+
+            if result.errors:
+                return 1
+
+            print_version_header()
+            info("Extraction complete:")
+            info(f"  Output:       {result.output_path}")
+            info(f"  Files written: {result.files_written}")
+            info(f"  Dirs created:  {result.directories_created}")
+            info(f"  Bytes written: {result.bytes_written}")
+            return 0
+
+        # Default PFS unpack path (existing behaviour).
+        result: PFSExtractionResult = extract_pfs_image(
             image=image,
             output_path=output_path,
             progress=Progress(enabled=True),
+            ekpfs=parse_ekpfs_key_hex(getattr(args, "ekpfs_key", None)),
+            new_crypt=bool(getattr(args, "new_crypt", False)),
+            deep=deep,
+            selectors=selectors,
         )
+
         for w in result.warnings:
             info(w)
         for e in result.errors:
@@ -1991,33 +2107,9 @@ def cli_mkpfs_extract_run(args: argparse.Namespace) -> int:
         info(f"  Dirs created:  {result.directories_created}")
         info(f"  Bytes written: {result.bytes_written}")
         return 0
-
-    # Default PFS unpack path (existing behaviour).
-    result: PFSExtractionResult = extract_pfs_image(
-        image=image,
-        output_path=output_path,
-        progress=Progress(enabled=True),
-        ekpfs=parse_ekpfs_key_hex(getattr(args, "ekpfs_key", None)),
-        new_crypt=bool(getattr(args, "new_crypt", False)),
-        deep=deep,
-        selectors=selectors,
-    )
-
-    for w in result.warnings:
-        info(w)
-    for e in result.errors:
-        info(e)
-
-    if result.errors:
-        return 1
-
-    print_version_header()
-    info("Extraction complete:")
-    info(f"  Output:       {result.output_path}")
-    info(f"  Files written: {result.files_written}")
-    info(f"  Dirs created:  {result.directories_created}")
-    info(f"  Bytes written: {result.bytes_written}")
-    return 0
+    finally:
+        if reset_needed:
+            set_progress_style(prev_style)
 
 
 def cli_mkpfs_main_parsers() -> argparse.ArgumentParser:
@@ -2054,6 +2146,11 @@ def cli_mkpfs_main_parsers() -> argparse.ArgumentParser:
     exfat_parser = pack_sub.add_parser("exfat", help="Build a raw exFAT image from a source directory")
     exfat_parser.epilog = "Examples:\r\n   mkpfs pack exfat './BREW1234-app' './BREW1234.exfat'\r\n"
     exfat_parser.add_argument("source_dir", help="Source app or homebrew folder")
+    exfat_parser.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Replace interactive progress bars with simple one-line status messages",
+    )
     exfat_parser.add_argument(
         "output",
         nargs="?",
@@ -2105,6 +2202,11 @@ def cli_mkpfs_main_parsers() -> argparse.ArgumentParser:
 
     check_parser = sub.add_parser("verify", help="Validate image structure and payload checksums")
     check_parser.add_argument("image_file", help="Path to input image (.ffpfs or .exfat)")
+    check_parser.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Replace interactive progress bars with simple one-line status messages",
+    )
     check_source_group = check_parser.add_mutually_exclusive_group()
     check_source_group.add_argument("--source-dir", help="Optional source folder for hierarchy and payload comparison")
     check_source_group.add_argument(
@@ -2172,6 +2274,11 @@ def cli_mkpfs_main_parsers() -> argparse.ArgumentParser:
     extract_parser = sub.add_parser("unpack", help="Extract files from image to destination directory")
     extract_parser.epilog = "Examples:\r\n   mkpfs unpack './BREW1234.ffpfs' './BREW1234-extracted/'\r\n"
     extract_parser.add_argument("image_file", help="Path to input image (.ffpfs or .exfat)")
+    extract_parser.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Replace interactive progress bars with simple one-line status messages",
+    )
     extract_parser.add_argument("output_dir", help="Destination directory for extraction")
     extract_parser.add_argument("--overwrite", action="store_true", help="Overwrite existing output path")
     extract_parser.add_argument(

--- a/mkpfs/pbar.py
+++ b/mkpfs/pbar.py
@@ -7,8 +7,43 @@ from __future__ import annotations
 
 import sys
 import time
+from typing import Final
 
 from .utils import human_readable_size
+
+# Global default style for new Progress instances: "bar" or "simple".
+# "bar": dynamic progress bar with percentage, speed, and ETA.
+# "simple": print a one-line status per phase (suitable for logs/CI).
+_DEFAULT_PROGRESS_STYLE: str = "bar"
+
+
+def set_progress_style(style: str) -> None:
+    """Set the default style for subsequently created Progress instances.
+
+    Args:
+        style: Either "bar" (default) or "simple".
+    """
+    global _DEFAULT_PROGRESS_STYLE
+    normalized: str = style.strip().lower()
+    if normalized not in {"bar", "simple"}:
+        normalized = "bar"
+    _DEFAULT_PROGRESS_STYLE = normalized
+
+
+def get_progress_style() -> str:
+    """Return the current default progress style ("bar" or "simple")."""
+    return _DEFAULT_PROGRESS_STYLE
+
+
+_SIMPLE_PHASE_MESSAGES: Final[dict[str, str]] = {
+    "scan": "Discovering files...",
+    "compress": "Compressing files...",
+    "write": "Writing image...",
+    "verify": "Verifying files...",
+    "compare": "Comparing files...",
+    "extract": "Extracting files...",
+    "exfat": "Building exFAT image...",
+}
 
 
 class Progress:
@@ -20,15 +55,23 @@ class Progress:
     Attributes:
         enabled: Whether progress output is active.
         width: Width of the visual progress bar in characters.
+        style: Rendering style, "bar" or "simple".
     """
 
-    def __init__(self, enabled: bool = True, width: int = 32) -> None:
+    def __init__(self, enabled: bool = True, width: int = 32, *, style: str | None = None) -> None:
         self.enabled: bool = enabled
         self.width: int = width
+        self.style: str = (style or _DEFAULT_PROGRESS_STYLE).strip().lower()
+        if self.style not in {"bar", "simple"}:
+            self.style = "bar"
         self.last_phase: str | None = None
         self.phase_start_time: dict[str, float] = {}
         self.phase_bytes: dict[str, int] = {}  # Track bytes processed per phase
         self.phase_last_len: dict[str, int] = {}  # Track last written line length per phase
+        self._printed_simple: set[str] = set()
+
+    def _simple_status_for_phase(self, phase: str) -> str:
+        return _SIMPLE_PHASE_MESSAGES.get(phase.lower(), f"{phase.capitalize()}. Please wait...")
 
     def step(self, phase: str, done: int, total: int, bytes_processed: int = 0) -> None:
         """Update progress for a named phase.
@@ -42,6 +85,16 @@ class Progress:
                 the progress will display byte-based throughput and ETA.
         """
         if not self.enabled:
+            return
+
+        # Simple mode: print a concise one-line status the first time we see the phase.
+        if self.style == "simple":
+            key: str = phase.lower()
+            if key not in self._printed_simple:
+                sys.stderr.write(self._simple_status_for_phase(key) + "\n")
+                sys.stderr.flush()
+                self._printed_simple.add(key)
+            self.last_phase = phase
             return
 
         # Initialize phase tracking if needed

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -176,6 +176,7 @@ class TestCliSmokeIntegration(CliTestCase):
         self.assertIn("--verify-structure", result.stdout)
         self.assertIn("--no-verify-structure", result.stdout)
         self.assertIn("--skip-verification", result.stdout)
+        self.assertIn("--no-progress", result.stdout)
 
         result = subprocess.run(
             [sys.executable, "-m", "mkpfs", "pack", "file", "--help"],
@@ -190,7 +191,38 @@ class TestCliSmokeIntegration(CliTestCase):
         self.assertIn("--verify-structure", result.stdout)
         self.assertIn("--no-verify-structure", result.stdout)
         self.assertIn("--skip-verification", result.stdout)
+        self.assertIn("--no-progress", result.stdout)
         self.assertNotIn("--require-game-files", result.stdout)
+
+    def test_no_progress_replaces_bars_with_simple_messages_for_stream_pack(self) -> None:
+        """--no-progress should replace dynamic bars with concise 'Please wait...' messages."""
+        tmp_path: Path = self.make_temp_path()
+        src: Path = tmp_path / "PPSA.exfat"
+        # Small but non-trivial input to exercise the streaming path
+        src.write_bytes(b"GAMEDATA" * 5000 + b"\x00" * 80000)
+        out: Path = tmp_path / "PPSA.ffpfsc"
+        stdout_buffer: StringIO = StringIO()
+        stderr_buffer: StringIO = StringIO()
+        with redirect_stdout(stdout_buffer), redirect_stderr(stderr_buffer):
+            rc: int = cli_mkpfs_main(
+                [
+                    "pack",
+                    "file",
+                    str(src),
+                    str(out),
+                    "--version",
+                    "PS5",
+                    "--inode-bits",
+                    "32",
+                    "--temp-folder",
+                    str(tmp_path / "temp"),
+                    "--no-progress",
+                    "--no-adjust-output-file-extension",
+                ]
+            )
+        self.assertEqual(rc, 0)
+        combined: str = stdout_buffer.getvalue() + stderr_buffer.getvalue()
+        self.assertIn("Compressing files...", combined)
 
     def test_pack_file_defaults_to_32_bit_inodes_and_verify_source_file_succeeds(self) -> None:
         """Single-file packing should keep 32-bit inode defaults and verify against the source file."""

--- a/tests/mkpfs/test_pbar.py
+++ b/tests/mkpfs/test_pbar.py
@@ -49,3 +49,18 @@ class TestProgressBarHelpers(unittest.TestCase):
             progress.step("scan", 2, 2, bytes_processed=200)
 
         self.assertIn("%", stderr_buffer.getvalue())
+
+    def test_simple_style_prints_concise_status_once_per_phase(self) -> None:
+        """Simple style should write a one-line status per phase and avoid duplicate lines."""
+        progress: Progress = Progress(enabled=True, style="simple")
+        stderr_buffer: StringIO = StringIO()
+        with redirect_stderr(stderr_buffer):
+            # Multiple updates for the same phase should produce only one line.
+            progress.step("compress", 1, 100, bytes_processed=1024)
+            progress.step("compress", 50, 100, bytes_processed=1024 * 1024)
+            # A new phase should produce a new concise line.
+            progress.step("verify", 1, 10, bytes_processed=0)
+        text: str = stderr_buffer.getvalue()
+        # Only one line for compress
+        self.assertEqual(text.count("Compressing files..."), 1)
+        self.assertIn("Verifying files...", text)


### PR DESCRIPTION
- Adds --no-progress to pack (folder/file/exfat), verify, and unpack\n- Simple progress style prints concise '...files...' per phase instead of bars\n- README updated to list the flag in command option tables\n- Tests updated and passing (380 passed)