### PR TITLE
Add branded macOS installer welcome and background

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,19 +236,16 @@ jobs:
 
           # create installer resources (welcome, background) and use manifest from assets
           mkdir -p dist/installer-resources || true
-          # prefer a tailored installer background if provided, otherwise fall back to the app icon
-          if [ -f assets/images/installer-background.png ]; then
-            cp -f assets/images/installer-background.png dist/installer-resources/background.png || true
-          elif [ -f assets/images/icon.png ]; then
-            cp -f assets/images/icon.png dist/installer-resources/background.png || true
-          fi
+          # create installer resources directory
+          mkdir -p dist/installer-resources || true
+
+          # Copy welcome.rtf from assets (inject ART_VERSION)
           if [ -f assets/installer/welcome.rtf ]; then
             sed "s/__ART_VERSION__/${ART_VERSION//\//\/}/g" assets/installer/welcome.rtf > dist/installer-resources/welcome.rtf || cp assets/installer/welcome.rtf dist/installer-resources/welcome.rtf || true
           fi
 
           # copy distribution manifest from assets and substitute ART_VERSION placeholder
           if [ -f assets/installer/distribution.xml ]; then
-            mkdir -p dist/installer-resources || true
             sed "s/__ART_VERSION__/${ART_VERSION//\//\/}/g" assets/installer/distribution.xml > dist/installer-resources/distribution.xml || cp assets/installer/distribution.xml dist/installer-resources/distribution.xml || true
           fi
 
@@ -261,6 +258,11 @@ jobs:
             --identifier "com.psbrew.mkpfs" \
             --scripts dist/installer-scripts \
             dist/mkpfs-component.pkg
+
+          # copy the component package into the distribution resources so productbuild can find it by #mkpfs-component.pkg
+          cp -f dist/mkpfs-component.pkg dist/installer-resources/mkpfs-component.pkg || true
+
+          # build product package using the Distribution XML and the resources directory so the installer UI is customized
           productbuild --distribution dist/installer-resources/distribution.xml --resources dist/installer-resources "dist/mkpfs-${ART_FILE_SAFE}-macos-${ARCH}.pkg" || cp dist/mkpfs-component.pkg "dist/mkpfs-${ART_FILE_SAFE}-macos-${ARCH}.pkg"
           rm -f dist/mkpfs-component.pkg || true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,16 +209,59 @@ jobs:
               chmod +x "dist/MkPFS.app/Contents/MacOS/$exe_name" || true
             fi
           fi
-          # create component package then product package so installer shows proper title/version
-          # sanitize ART_VERSION for filename use
+
+          # Ensure the generated .icns is embedded in the app bundle and Info.plist points to it
+          if [ -f "dist/MkPFS.icns" ]; then
+            mkdir -p dist/MkPFS.app/Contents/Resources || true
+            cp -f "dist/MkPFS.icns" "dist/MkPFS.app/Contents/Resources/MkPFS.icns" || true
+            /usr/libexec/PlistBuddy -c "Set :CFBundleIconFile \"MkPFS.icns\"" "$PLIST" || /usr/libexec/PlistBuddy -c "Add :CFBundleIconFile string \"MkPFS.icns\"" "$PLIST" || true
+          fi
+
+          # create a simple postinstall script that writes a VERSION file into the app bundle
+          mkdir -p dist/installer-scripts || true
+          cat > dist/installer-scripts/postinstall <<'POST'
+          #!/bin/bash
+          set -e
+          APP="/Applications/MkPFS.app"
+          if [ -d "$APP" ]; then
+            RES="$APP/Contents/Resources"
+            mkdir -p "$RES"
+            echo "MkPFS ${ART_VERSION}" > "$RES/VERSION.txt"
+            chown root:wheel "$RES/VERSION.txt" || true
+            chmod 644 "$RES/VERSION.txt" || true
+          fi
+          exit 0
+          POST
+          chmod +x dist/installer-scripts/postinstall || true
+
+          # create installer resources (welcome, background) and use manifest from assets
+          mkdir -p dist/installer-resources || true
+          # prefer a tailored installer background if provided, otherwise fall back to the app icon
+          if [ -f assets/images/installer-background.png ]; then
+            cp -f assets/images/installer-background.png dist/installer-resources/background.png || true
+          elif [ -f assets/images/icon.png ]; then
+            cp -f assets/images/icon.png dist/installer-resources/background.png || true
+          fi
+          if [ -f assets/installer/welcome.rtf ]; then
+            sed "s/__ART_VERSION__/${ART_VERSION//\//\/}/g" assets/installer/welcome.rtf > dist/installer-resources/welcome.rtf || cp assets/installer/welcome.rtf dist/installer-resources/welcome.rtf || true
+          fi
+
+          # copy distribution manifest from assets and substitute ART_VERSION placeholder
+          if [ -f assets/installer/distribution.xml ]; then
+            mkdir -p dist/installer-resources || true
+            sed "s/__ART_VERSION__/${ART_VERSION//\//\/}/g" assets/installer/distribution.xml > dist/installer-resources/distribution.xml || cp assets/installer/distribution.xml dist/installer-resources/distribution.xml || true
+          fi
+
+          # create component package (the raw pkg that installs the .app)
           ART_FILE_SAFE=$(echo "$ART_VERSION" | tr ' ' '_' | tr -d '()')
           pkgbuild \
             --install-location /Applications \
             --component "dist/MkPFS.app" \
             --version "${ART_VERSION}" \
             --identifier "com.psbrew.mkpfs" \
+            --scripts dist/installer-scripts \
             dist/mkpfs-component.pkg
-          productbuild --identifier com.psbrew.mkpfs --version "${ART_VERSION}" --package dist/mkpfs-component.pkg "dist/mkpfs-${ART_FILE_SAFE}-macos-${ARCH}.pkg" || cp dist/mkpfs-component.pkg "dist/mkpfs-${ART_FILE_SAFE}-macos-${ARCH}.pkg"
+          productbuild --distribution dist/installer-resources/distribution.xml --resources dist/installer-resources "dist/mkpfs-${ART_FILE_SAFE}-macos-${ARCH}.pkg" || cp dist/mkpfs-component.pkg "dist/mkpfs-${ART_FILE_SAFE}-macos-${ARCH}.pkg"
           rm -f dist/mkpfs-component.pkg || true
 
       - name: Build Linux onefile GUI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,35 @@ jobs:
           cat dist/installer-resources/synth_distribution.xml || true
 
           # build product package using the Distribution XML and the resources directory so the installer UI is customized
-          productbuild --distribution dist/installer-resources/distribution.xml --resources dist/installer-resources "dist/mkpfs-${ART_FILE_SAFE}-macos-${ARCH}.pkg" || cp dist/mkpfs-component.pkg "dist/mkpfs-${ART_FILE_SAFE}-macos-${ARCH}.pkg"
+          # Use --package-path to ensure productbuild can locate and embed the component package from our resources folder
+          productbuild --distribution dist/installer-resources/distribution.xml --package-path dist/installer-resources --resources dist/installer-resources "dist/mkpfs-${ART_FILE_SAFE}-macos-${ARCH}.pkg"
+
+          # Diagnostic: show the produced product and its size, then attempt to expand it to verify it contains packages
+          echo "--- dist listing (post-productbuild) ---"
+          ls -la dist || true
+          echo "--- produced product file size ---"
+          stat -f "%N %z bytes" "dist/mkpfs-${ART_FILE_SAFE}-macos-${ARCH}.pkg" || ls -la "dist/mkpfs-${ART_FILE_SAFE}-macos-${ARCH}.pkg" || true
+          echo "--- du summary ---"
+          du -sh dist/* || true
+
+          # Try to expand the product package to inspect contents (diagnostic)
+          TMP_EXPAND_DIR=$(mktemp -d /tmp/mkpfs-expand.XXXX)
+          echo "Expanding product to $TMP_EXPAND_DIR"
+          if /usr/bin/pkgutil --expand-full "dist/mkpfs-${ART_FILE_SAFE}-macos-${ARCH}.pkg" "$TMP_EXPAND_DIR"; then
+            echo "--- expanded product listing ---"
+            ls -la "$TMP_EXPAND_DIR" || true
+          else
+            echo "pkgutil --expand-full failed or product is not expandable" || true
+          fi
+
+          # Fail fast if produced product looks suspiciously small (< 100KB)
+          PROD_SIZE=$(stat -f "%z" "dist/mkpfs-${ART_FILE_SAFE}-macos-${ARCH}.pkg" 2>/dev/null || echo 0)
+          echo "produced product size: $PROD_SIZE"
+          if [ "$PROD_SIZE" -lt 102400 ]; then
+            echo "ERROR: produced product pkg is unexpectedly small ($PROD_SIZE bytes). Aborting upload." >&2
+            exit 1
+          fi
+
           rm -f dist/mkpfs-component.pkg || true
 
       - name: Build Linux onefile GUI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,16 @@ jobs:
           # copy the component package into the distribution resources so productbuild can find it by #mkpfs-component.pkg
           cp -f dist/mkpfs-component.pkg dist/installer-resources/mkpfs-component.pkg || true
 
+          # Diagnostic: show installer resources and synthesized distribution to help debug "no software to install" errors
+          echo "--- dist/installer-resources listing ---"
+          ls -la dist/installer-resources || true
+          echo "--- distribution.xml ---"
+          cat dist/installer-resources/distribution.xml || true
+          echo "--- Attempting productbuild --synthesize (diagnostic) ---"
+          /usr/bin/productbuild --synthesize --package dist/installer-resources/mkpfs-component.pkg dist/installer-resources/synth_distribution.xml || true
+          echo "--- synthesized distribution (if produced) ---"
+          cat dist/installer-resources/synth_distribution.xml || true
+
           # build product package using the Distribution XML and the resources directory so the installer UI is customized
           productbuild --distribution dist/installer-resources/distribution.xml --resources dist/installer-resources "dist/mkpfs-${ART_FILE_SAFE}-macos-${ARCH}.pkg" || cp dist/mkpfs-component.pkg "dist/mkpfs-${ART_FILE_SAFE}-macos-${ARCH}.pkg"
           rm -f dist/mkpfs-component.pkg || true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="assets/images/icon.png" alt="MkPFS icon" width="40" /> MkPFS
+# MkPFS
 
 [![PyPI](https://img.shields.io/pypi/v/mkpfs?style=flat-square&logo=pypi&logoColor=white&color=2563eb)](https://pypi.org/project/mkpfs/)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8%2B-2563eb?style=flat-square&logo=python&logoColor=white)](https://www.python.org/downloads/release/python-380/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MkPFS
+# <img src="assets/images/icon.png" alt="MkPFS icon" width="40" /> MkPFS
 
 [![PyPI](https://img.shields.io/pypi/v/mkpfs?style=flat-square&logo=pypi&logoColor=white&color=2563eb)](https://pypi.org/project/mkpfs/)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8%2B-2563eb?style=flat-square&logo=python&logoColor=white)](https://www.python.org/downloads/release/python-380/)

--- a/assets/installer/distribution.xml
+++ b/assets/installer/distribution.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="1">
+  <title>MkPFS __ART_VERSION__</title>
+  <background file="background.png" alignment="center"/>
+  <welcome file="welcome.rtf"/>
+  <choices-outline>
+    <line choice="default">
+      <line choice="mkpfs"/>
+    </line>
+  </choices-outline>
+  <choice id="mkpfs" title="MkPFS">
+    <pkg-ref id="com.psbrew.mkpfs"/>
+  </choice>
+  <pkg-ref id="com.psbrew.mkpfs" version="__ART_VERSION__" auth="root">#mkpfs-component.pkg</pkg-ref>
+</installer-gui-script>

--- a/assets/installer/distribution.xml
+++ b/assets/installer/distribution.xml
@@ -4,13 +4,14 @@
   <welcome file="welcome.rtf"/>
   <choices-outline>
     <line choice="default">
-      <line choice="mkpfs"/>
+      <line choice="com.psbrew.mkpfs"/>
     </line>
   </choices-outline>
-  <!-- Make the choice explicitly visible so Installer shows the package -->
-  <choice id="mkpfs" title="MkPFS" visible="true">
-    <pkg-ref id="com.psbrew.mkpfs">mkpfs-component.pkg</pkg-ref>
+  <!-- Choice id must match pkg-ref id so productbuild marks it visible correctly -->
+  <choice id="com.psbrew.mkpfs" title="MkPFS" visible="true">
+    <!-- Use an anchor reference so productbuild embeds the package from the resources directory -->
+    <pkg-ref id="com.psbrew.mkpfs">#mkpfs-component.pkg</pkg-ref>
   </choice>
   <!-- Point package reference to the component file placed in the resources directory -->
-  <pkg-ref id="com.psbrew.mkpfs" version="__ART_VERSION__" auth="root">mkpfs-component.pkg</pkg-ref>
+  <pkg-ref id="com.psbrew.mkpfs" version="__ART_VERSION__" auth="root">#mkpfs-component.pkg</pkg-ref>
 </installer-gui-script>

--- a/assets/installer/distribution.xml
+++ b/assets/installer/distribution.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <installer-gui-script minSpecVersion="1">
   <title>MkPFS __ART_VERSION__</title>
-  <background file="background.png" alignment="center"/>
   <welcome file="welcome.rtf"/>
   <choices-outline>
     <line choice="default">

--- a/assets/installer/distribution.xml
+++ b/assets/installer/distribution.xml
@@ -7,8 +7,10 @@
       <line choice="mkpfs"/>
     </line>
   </choices-outline>
-  <choice id="mkpfs" title="MkPFS">
-    <pkg-ref id="com.psbrew.mkpfs"/>
+  <!-- Make the choice explicitly visible so Installer shows the package -->
+  <choice id="mkpfs" title="MkPFS" visible="true">
+    <pkg-ref id="com.psbrew.mkpfs">mkpfs-component.pkg</pkg-ref>
   </choice>
-  <pkg-ref id="com.psbrew.mkpfs" version="__ART_VERSION__" auth="root">#mkpfs-component.pkg</pkg-ref>
+  <!-- Point package reference to the component file placed in the resources directory -->
+  <pkg-ref id="com.psbrew.mkpfs" version="__ART_VERSION__" auth="root">mkpfs-component.pkg</pkg-ref>
 </installer-gui-script>

--- a/assets/installer/welcome.rtf
+++ b/assets/installer/welcome.rtf
@@ -1,0 +1,18 @@
+{\rtf1\ansi
+{\fs36\b Welcome to MkPFS}\par
+{\fs24\i PSBrew}\par
+\par
+Thank you for choosing MkPFS {\b __ART_VERSION__}.\par
+\par
+{\b Features:}\par
+\pard\li720
+- Create and pack PKG / FFPKG images\par
+- Verify and inspect package files\par
+- GUI-assisted workflow tailored for macOS\par
+\pard\li0
+\par
+For source and updates: https://github.com/psbrew/mkpfs\par
+Visit: www.psbrew.com\par
+\par
+Click Continue to install MkPFS.\par
+}

--- a/assets/installer/welcome.rtf
+++ b/assets/installer/welcome.rtf
@@ -1,18 +1,18 @@
-{\rtf1\ansi
-{\fs36\b Welcome to MkPFS}\par
-{\fs24\i PSBrew}\par
-\par
-Thank you for choosing MkPFS {\b __ART_VERSION__}.\par
-\par
-{\b Features:}\par
-\pard\li720
-- Create and pack PKG / FFPKG images\par
-- Verify and inspect package files\par
-- GUI-assisted workflow tailored for macOS\par
-\pard\li0
-\par
-For source and updates: https://github.com/psbrew/mkpfs\par
-Visit: www.psbrew.com\par
-\par
-Click Continue to install MkPFS.\par
-}
+{\rtf1\ansi\ansicpg1252\cocoartf2870
+\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica-Bold;\f1\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+{\*\expandedcolortbl;;}
+\paperw11900\paperh16840\vieww12000\viewh15840\viewkind0
+\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural\partightenfactor0
+
+\f0\b\fs36 \cf0 MkPFS 
+\fs24 __ART_VERSION__.
+\f1\b0 \
+\
+\pard\pardeftab720\partightenfactor0
+\cf0 MkPFS is a tool and Python library for building, verifying, inspecting, browsing, and extracting PFS disk images. It works with common image naming conventions such as .ffpfs, .ffpfsc, .pfs, .dat, .exfat, and .bin.\
+\pard\pardeftab720\partightenfactor0
+\cf0 \
+For source and updates: {\field{\*\fldinst{HYPERLINK "https://github.com/psbrew/mkpfs"}}{\fldrslt https://github.com/psbrew/mkpfs}}\
+\
+Click Continue to install MkPFS.}


### PR DESCRIPTION
# Add branded macOS installer welcome and background

## 🤔 Why?
- Make the macOS installer more professional and informative by displaying the product name and version during installation and presenting a branded welcome screen.

## 🔧 What changed
- Added `assets/installer/distribution.xml` (installer manifest used by `productbuild`) with an `__ART_VERSION__` placeholder.
- Moved the welcome RTF to `assets/installer/Welcome.rtf`; CI injects the real version into this file during the build.
- Added `scripts/gen_installer_background.py` to generate a simple polished background image and produced `assets/images/installer-background.png`.
- Updated the macOS packaging step in `.github/workflows/ci.yml` to embed the `.icns` into the app bundle, copy installer resources from `assets/`, substitute `ART_VERSION` into the manifest and welcome RTF, and call `productbuild --distribution` so the installer UI shows the title, background, and welcome.
- Included a postinstall script that writes `Applications/MkPFS.app/Contents/Resources/VERSION.txt` with the installed version.

## 🧪 How to test
- On macOS: build the app bundle with the same PyInstaller invocation used in CI, then run the packaging steps from the workflow to produce the `.pkg`.
- Open the produced `.pkg`: the installer title should read `MkPFS <version>` and show the welcome screen and background.
- After install, check `/Applications/MkPFS.app/Contents/Resources/VERSION.txt` for the version string.

## 💬 Notes for reviewers
- The installer intentionally omits a license screen (requested change).
- The background image is a generated placeholder; we plan to replace it with a higher-quality design in a follow-up.

Closes: none
