### PR TITLE
Default exFAT cluster to 64 KiB

### DIFF
--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -2168,7 +2168,7 @@ def cli_mkpfs_main_parsers() -> argparse.ArgumentParser:
     exfat_parser.add_argument(
         "--cluster-size",
         default="auto",
-        help="exFAT cluster size in bytes or 'auto' (32 KiB, or 64 KiB for large-average-file trees)",
+        help="exFAT cluster size in bytes or 'auto' (default: 65536 - SMP/LVD-optimal 64 KiB)",
     )
     exfat_parser.add_argument("--overwrite", action="store_true", help="Overwrite an existing output file")
     exfat_parser.add_argument("--verbose", action="store_true", help="Verbose output")

--- a/mkpfs/exfat_writer.py
+++ b/mkpfs/exfat_writer.py
@@ -29,9 +29,7 @@ _FAT_OFFSET_SECTORS: int = 128  # leave aligned room before the FAT (matches new
 _NUMBER_OF_FATS: int = 1
 _FAT_ENTRY_EOC: int = 0xFFFFFFFF
 _FAT_ENTRY_MEDIA: int = 0xFFFFFFF8
-_DEFAULT_CLUSTER_SIZE: int = 32 * 1024
 _LARGE_CLUSTER_SIZE: int = 64 * 1024
-_LARGE_FILE_THRESHOLD: int = 1024 * 1024
 _VOLUME_SERIAL: int = 0x4D6B5046  # "MkPF"; fixed for deterministic output
 _FIXED_TIMESTAMP: int = (2024 - 1980) << 25 | 1 << 21 | 1 << 16  # 2024-01-01 00:00:00
 
@@ -98,21 +96,10 @@ def _scan_tree(root: Path) -> _Node:
 
 
 def _choose_cluster_size(root: _Node) -> int:
-    total: int = 0
-    count: int = 0
-
-    def _accum(node: _Node) -> None:
-        nonlocal total, count
-        for child in node.children:
-            if child.is_dir:
-                _accum(child)
-            else:
-                total += child.size
-                count += 1
-
-    _accum(root)
-    avg: int = total // count if count else 0
-    return _LARGE_CLUSTER_SIZE if avg >= _LARGE_FILE_THRESHOLD else _DEFAULT_CLUSTER_SIZE
+    # SMP requires 64 KiB allocation units for the LVD/BFS fast-path. Use the
+    # larger cluster size unconditionally so images created by mkpfs are
+    # eligible by default (previously we chose 32K for small-file sets).
+    return _LARGE_CLUSTER_SIZE
 
 
 def _directory_entry_count(node: _Node, *, is_root: bool) -> int:

--- a/mkpfs/gui/panels/exfat_panel.py
+++ b/mkpfs/gui/panels/exfat_panel.py
@@ -26,7 +26,7 @@ class ExfatPanel(BasePanel):
         """
         self._src: ctk.StringVar = ctk.StringVar()
         self._out: ctk.StringVar = ctk.StringVar()
-        self._cluster_size: ctk.StringVar = ctk.StringVar(value="auto")
+        self._cluster_size: ctk.StringVar = ctk.StringVar(value="65536")
         self._overwrite: ctk.BooleanVar = ctk.BooleanVar(value=False)
         super().__init__(parent)
         # Auto-populate output path from source folder selection.

--- a/tests/mkpfs/test_exfat_writer.py
+++ b/tests/mkpfs/test_exfat_writer.py
@@ -104,15 +104,16 @@ class TestExfatWriterFormat(ExfatWriterTestCase):
         self.assertEqual(geo.bytes_per_sector, 512)
         self.assertEqual(geo.cluster_size, 64 * 1024)
 
-    def test_large_files_select_64k_clusters(self) -> None:
+    def test_explicit_cluster_size_override(self) -> None:
         tmp = self.make_temp_path()
         src = tmp / "src"
         src.mkdir()
-        (src / "big.bin").write_bytes(os.urandom(2 * 1024 * 1024))  # avg >= 1 MiB
+        # create a sizeable file but request a 32 KiB cluster explicitly
+        (src / "big.bin").write_bytes(os.urandom(2 * 1024 * 1024))
         image = tmp / "out.exfat"
-        write_exfat_image(src, image)
+        write_exfat_image(src, image, cluster_size=32 * 1024)
         with image.open("rb") as fh:
-            self.assertEqual(exfat.ExfatReader(fh).geometry.cluster_size, 64 * 1024)
+            self.assertEqual(exfat.ExfatReader(fh).geometry.cluster_size, 32 * 1024)
 
 
 class TestExfatWriterAutoName(ExfatWriterTestCase):

--- a/tests/mkpfs/test_exfat_writer.py
+++ b/tests/mkpfs/test_exfat_writer.py
@@ -102,7 +102,7 @@ class TestExfatWriterFormat(ExfatWriterTestCase):
         with image.open("rb") as fh:
             geo = exfat.ExfatReader(fh).geometry
         self.assertEqual(geo.bytes_per_sector, 512)
-        self.assertIn(geo.cluster_size, (32 * 1024, 64 * 1024))
+        self.assertEqual(geo.cluster_size, 64 * 1024)
 
     def test_large_files_select_64k_clusters(self) -> None:
         tmp = self.make_temp_path()


### PR DESCRIPTION
# Default exFAT cluster to 64 KiB

Conservative, backward-compatible default: exFAT supports 64 KiB clusters and the change improves performance with ShadowMountPlus on PS5.

## 🤔 Why?
- ShadowMountPlus 1.7alpha5 requires exFAT images to use a 64 KiB allocation unit to be eligible for the LVD/BFS 64 KiB batching fast-path. MkPFS previously picked 32 KiB for small-file trees which prevented those images from benefiting.

## 🔧 What changed
- Force MkPFS to select 64 KiB clusters by default when writing exFAT images.
- Update CLI help text to document the 64 KiB default.
- Set the GUI exFAT panel default to 65536 so GUI users produce 64 KiB images.
- Tighten exFAT writer unit test to assert 64 KiB cluster size.
