### PR TITLE
GUI: Auto populate output form fields

### DIFF
--- a/mkpfs/gui/panels/batch.py
+++ b/mkpfs/gui/panels/batch.py
@@ -1,4 +1,7 @@
+
 """Batch Convert operation panel for the mkpfs GUI."""
+from pathlib import Path
+
 
 from typing import Any
 
@@ -6,7 +9,7 @@ import customtkinter as ctk
 
 from ..i18n import tr
 from ..theme import _BORDER_BRIGHT
-from ..widgets import NeonCheckbox, OptionRow, PathRow, SectionLabel
+from ..widgets import NeonCheckbox, PathRow, SectionLabel
 from .base import BasePanel
 
 
@@ -25,11 +28,12 @@ class BatchPanel(BasePanel):
         """
         self._src: ctk.StringVar = ctk.StringVar()
         self._out: ctk.StringVar = ctk.StringVar()
-        self._version: ctk.StringVar = ctk.StringVar(value="PS5")
         self._compress: ctk.BooleanVar = ctk.BooleanVar(value=True)
         self._overwrite: ctk.BooleanVar = ctk.BooleanVar(value=False)
         self._dry_run: ctk.BooleanVar = ctk.BooleanVar(value=False)
         super().__init__(parent)
+        # Auto-populate output folder from source selection when empty.
+        self._src.trace_add("write", self._on_src_changed)
 
     def _build_controls(self, card: "GlassCard") -> None:  # ruff: ignore[undefined-name]
         card.columnconfigure(0, weight=1)
@@ -65,10 +69,6 @@ class BatchPanel(BasePanel):
         opt.grid(row=5, column=0, columnspan=2, sticky="ew", padx=16, pady=(0, 14))
         opt.columnconfigure((0, 1), weight=1)
 
-        OptionRow(opt, tr("bt_version"), self._version, ["PS4", "PS5"], accent=self._accent).grid(
-            row=0, column=0, sticky="ew", padx=(0, 12)
-        )
-
         chk: ctk.CTkFrame = ctk.CTkFrame(opt, fg_color="transparent")
         chk.grid(row=0, column=1, sticky="nw", padx=(8, 0))
 
@@ -94,8 +94,6 @@ class BatchPanel(BasePanel):
             "batch",
             src,
             out,
-            "--version",
-            self._version.get(),
         ]
 
         if not self._compress.get():
@@ -106,3 +104,21 @@ class BatchPanel(BasePanel):
             args.append("--dry-run")
 
         self._run_mkpfs(args)
+
+    def _on_src_changed(self, *_args: Any) -> None:
+        """Auto-populate an output folder inside the selected source directory.
+
+        Only runs when the output field is currently empty and the source
+        resolves to an existing directory to avoid interfering with manual
+        typing.
+        """
+        if self._out.get().strip():
+            return
+        src_path: str = self._src.get().strip()
+        if not src_path:
+            return
+        p: Path = Path(src_path)
+        if not p.is_dir():
+            return
+        # Place converted output as a subdirectory of the source folder.
+        self._out.set(str(p / "converted"))

--- a/mkpfs/gui/panels/batch.py
+++ b/mkpfs/gui/panels/batch.py
@@ -1,8 +1,6 @@
-
 """Batch Convert operation panel for the mkpfs GUI."""
+
 from pathlib import Path
-
-
 from typing import Any
 
 import customtkinter as ctk

--- a/mkpfs/gui/panels/exfat_panel.py
+++ b/mkpfs/gui/panels/exfat_panel.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import customtkinter as ctk
 
+from ...utils import ui_sanitize_basename
 from ..i18n import tr
 from ..theme import _BORDER_BRIGHT
 from ..widgets import GlassCard, NeonCheckbox, OptionRow, PathRow, SectionLabel
@@ -51,7 +52,7 @@ class ExfatPanel(BasePanel):
         # avoids disk I/O on partial paths during manual typing.
         if not p.is_dir():
             return
-        self._out.set(str(p.parent / (p.name + ".img")))
+        self._out.set(str(p.parent / (ui_sanitize_basename(p.name) + ".exfat")))
 
     def _build_controls(self, card: GlassCard) -> None:
         """Build the panel controls."""

--- a/mkpfs/gui/panels/exfat_panel.py
+++ b/mkpfs/gui/panels/exfat_panel.py
@@ -1,11 +1,9 @@
 """EXFAT image creation panel for the mkpfs GUI."""
 
-from pathlib import Path
 from typing import Any
 
 import customtkinter as ctk
 
-from ...utils import ui_sanitize_basename
 from ..i18n import tr
 from ..theme import _BORDER_BRIGHT
 from ..widgets import GlassCard, NeonCheckbox, OptionRow, PathRow, SectionLabel
@@ -35,25 +33,6 @@ class ExfatPanel(BasePanel):
         # paths are never overwritten.
         self._src.trace_add("write", self._on_src_changed)
 
-    def _on_src_changed(self, *_args: Any) -> None:
-        """Auto-populate output path when the user selects a source folder.
-
-        Computes the output as ``<source_dir>/<source_name>.img`` in the
-        same parent directory.  Only fires when the output field is empty
-        so a manually-typed path is preserved.
-        """
-        if self._out.get().strip():
-            return
-        src_path: str = self._src.get().strip()
-        if not src_path:
-            return
-        p: Path = Path(src_path)
-        # Only auto-populate when the source is an existing directory;
-        # avoids disk I/O on partial paths during manual typing.
-        if not p.is_dir():
-            return
-        self._out.set(str(p.parent / (ui_sanitize_basename(p.name) + ".exfat")))
-
     def _build_controls(self, card: GlassCard) -> None:
         """Build the panel controls."""
         card.columnconfigure(0, weight=1)
@@ -77,7 +56,7 @@ class ExfatPanel(BasePanel):
             tr("exf_out_label"),
             self._out,
             mode="save",
-            filetypes=[("EXFAT image", "*.img")],
+            filetypes=[("EXFAT image", "*.exfat")],
             placeholder=tr("exf_out_ph"),
             browse_label=tr("browse"),
         ).grid(row=2, column=0, columnspan=2, sticky="ew", padx=16, pady=(0, 14))

--- a/mkpfs/gui/panels/pack_file.py
+++ b/mkpfs/gui/panels/pack_file.py
@@ -1,4 +1,8 @@
+
 """Pack File operation panel for mkpfs GUI."""
+from pathlib import Path
+from ...utils import ui_sanitize_basename
+
 
 from typing import Any
 
@@ -6,7 +10,7 @@ import customtkinter as ctk
 
 from ..i18n import tr
 from ..theme import _BORDER_BRIGHT
-from ..widgets import GlassCard, NeonCheckbox, OptionRow, PathRow, SectionLabel
+from ..widgets import GlassCard, NeonCheckbox, PathRow, SectionLabel
 from .base import BasePanel
 
 
@@ -25,10 +29,12 @@ class PackFilePanel(BasePanel):
         """
         self._src: ctk.StringVar = ctk.StringVar()
         self._out: ctk.StringVar = ctk.StringVar()
-        self._version: ctk.StringVar = ctk.StringVar(value="PS4")
         self._compress: ctk.BooleanVar = ctk.BooleanVar(value=True)
         self._temp_folder: ctk.StringVar = ctk.StringVar()
         super().__init__(parent)
+
+        # Auto-populate output path from source file selection when empty.
+        self._src.trace_add("write", self._on_src_changed)
 
     def _build_controls(self, card: GlassCard) -> None:
         card.columnconfigure(0, weight=1)
@@ -67,10 +73,6 @@ class PackFilePanel(BasePanel):
         opt.grid(row=5, column=0, columnspan=2, sticky="ew", padx=16, pady=(0, 14))
         opt.columnconfigure((0, 1), weight=1)
 
-        OptionRow(opt, tr("pkf_version"), self._version, ["PS4", "PS5"], accent=self._accent).grid(
-            row=0, column=0, sticky="ew", padx=(0, 12)
-        )
-
         chk: ctk.CTkFrame = ctk.CTkFrame(opt, fg_color="transparent")
         chk.grid(row=0, column=1, sticky="nw", padx=(8, 0))
 
@@ -87,13 +89,31 @@ class PackFilePanel(BasePanel):
             browse_label=tr("browse"),
         ).grid(row=1, column=0, columnspan=2, sticky="ew", pady=(10, 0))
 
+    def _on_src_changed(self, *_args: Any) -> None:
+        """Auto-populate sensible output filename when user selects a source file.
+
+        Uses the source file stem, sanitized using ui_sanitize_basename, with
+        the .ffpfsc extension. Only fills the output when the output field is
+        currently empty.
+        """
+        if self._out.get().strip():
+            return
+        src_path: str = self._src.get().strip()
+        if not src_path:
+            return
+        p: Path = Path(src_path)
+        # Only when the source is a file
+        if not p.is_file():
+            return
+        self._out.set(str(p.parent / (ui_sanitize_basename(p.stem) + ".ffpfsc")))
+
     def _run_command(self) -> None:
         src: str = self._src.get().strip()
         out: str = self._out.get().strip()
         if not src or not out:
             self._emit(tr("pkf_err"), "error")
             return
-        args: list[str] = ["pack", "file", src, out, "--version", self._version.get()]
+        args: list[str] = ["pack", "file", src, out]
         if not self._compress.get():
             args.append("--no-compress")
         if temp := self._temp_folder.get().strip():

--- a/mkpfs/gui/panels/pack_file.py
+++ b/mkpfs/gui/panels/pack_file.py
@@ -1,13 +1,11 @@
-
 """Pack File operation panel for mkpfs GUI."""
+
 from pathlib import Path
-from ...utils import ui_sanitize_basename
-
-
 from typing import Any
 
 import customtkinter as ctk
 
+from ...utils import ui_sanitize_basename
 from ..i18n import tr
 from ..theme import _BORDER_BRIGHT
 from ..widgets import GlassCard, NeonCheckbox, PathRow, SectionLabel

--- a/mkpfs/gui/panels/pack_folder.py
+++ b/mkpfs/gui/panels/pack_folder.py
@@ -1,12 +1,15 @@
 """Pack Folder operation panel for mkpfs GUI."""
 
+from pathlib import Path
+
 from typing import Any
 
 import customtkinter as ctk
 
+from ...utils import ui_sanitize_basename
 from ..i18n import tr
 from ..theme import _BORDER_BRIGHT
-from ..widgets import GlassCard, NeonCheckbox, OptionRow, PathRow, SectionLabel
+from ..widgets import GlassCard, NeonCheckbox, PathRow, SectionLabel
 from .base import BasePanel
 
 
@@ -25,13 +28,14 @@ class PackFolderPanel(BasePanel):
         """
         self._src: ctk.StringVar = ctk.StringVar()
         self._out: ctk.StringVar = ctk.StringVar()
-        self._version: ctk.StringVar = ctk.StringVar(value="PS4")
         self._compress: ctk.BooleanVar = ctk.BooleanVar(value=True)
         self._signed: ctk.BooleanVar = ctk.BooleanVar(value=False)
         self._verify_after: ctk.BooleanVar = ctk.BooleanVar(value=False)
         self._dry_run: ctk.BooleanVar = ctk.BooleanVar(value=False)
         self._temp_folder: ctk.StringVar = ctk.StringVar()
         super().__init__(parent)
+        # Auto-populate output filename from source when empty.
+        self._src.trace_add("write", self._on_src_changed)
 
     def _build_controls(self, card: GlassCard) -> None:
         card.columnconfigure(0, weight=1)
@@ -69,11 +73,6 @@ class PackFolderPanel(BasePanel):
         opt: ctk.CTkFrame = ctk.CTkFrame(card, fg_color="transparent")
         opt.grid(row=5, column=0, columnspan=2, sticky="ew", padx=16, pady=(0, 14))
         opt.columnconfigure((0, 1), weight=1)
-
-        OptionRow(opt, tr("pf_version"), self._version, ["PS4", "PS5"], accent=self._accent).grid(
-            row=0, column=0, sticky="ew", padx=(0, 12)
-        )
-
         chk: ctk.CTkFrame = ctk.CTkFrame(opt, fg_color="transparent")
         chk.grid(row=0, column=1, sticky="nw", padx=(8, 0))
 
@@ -95,6 +94,24 @@ class PackFolderPanel(BasePanel):
             browse_label=tr("browse"),
         ).grid(row=1, column=0, columnspan=2, sticky="ew", pady=(10, 0))
 
+    def _on_src_changed(self, *_args: Any) -> None:
+        """Auto-populate an output basename for pack-folder when the source is chosen.
+
+        Applies ui_sanitize_basename to the source folder name, and uses the
+        canonical .ffpfsc extension. Only triggers when the output field is
+        currently empty and the source resolves to an existing directory.
+        """
+        if self._out.get().strip():
+            return
+        src_path: str = self._src.get().strip()
+        if not src_path:
+            return
+
+        p: Path = Path(src_path)
+        if not p.is_dir():
+            return
+        self._out.set(str(p.parent / (ui_sanitize_basename(p.name) + ".ffpfsc")))
+
     def _run_command(self) -> None:
         src: str = self._src.get().strip()
         out: str = self._out.get().strip()
@@ -104,7 +121,7 @@ class PackFolderPanel(BasePanel):
         if not out:
             self._emit(tr("pf_err_out"), "error")
             return
-        args: list[str] = ["pack", "folder", src, out, "--version", self._version.get()]
+        args: list[str] = ["pack", "folder", src, out]
         if not self._compress.get():
             args.append("--no-compress")
         if self._signed.get():

--- a/mkpfs/gui/panels/pack_folder.py
+++ b/mkpfs/gui/panels/pack_folder.py
@@ -1,7 +1,6 @@
 """Pack Folder operation panel for mkpfs GUI."""
 
 from pathlib import Path
-
 from typing import Any
 
 import customtkinter as ctk

--- a/mkpfs/gui/panels/unpack.py
+++ b/mkpfs/gui/panels/unpack.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import customtkinter as ctk
 
+from ...utils import ui_sanitize_basename
 from ..i18n import tr
 from ..theme import _BG_INPUT, _BORDER_BRIGHT, _FONT_LABEL, _FONT_MONO, _TEXT_PRIMARY, _TEXT_SECONDARY
 from ..widgets import GlassCard, NeonCheckbox, PathRow, SectionLabel
@@ -30,6 +31,8 @@ class UnpackPanel(BasePanel):
         self._ekpfs: ctk.StringVar = ctk.StringVar()
         self._new_crypt: ctk.BooleanVar = ctk.BooleanVar(value=False)
         super().__init__(parent)
+        # Auto-populate output folder from selected image when empty.
+        self._image.trace_add("write", self._on_image_changed)
 
     def _build_controls(self, card: GlassCard) -> None:
         card.columnconfigure(0, weight=1)
@@ -89,6 +92,23 @@ class UnpackPanel(BasePanel):
         NeonCheckbox(opt, text=tr("u_newcrypt"), variable=self._new_crypt, accent=self._accent).grid(
             row=1, column=1, sticky="w", padx=(8, 0)
         )
+
+    def _on_image_changed(self, *_args: Any) -> None:
+        """Auto-populate output folder when an image is selected.
+
+        Uses the image filename stem (sanitized) as a folder name under the
+        image's parent directory. Only fills when the output is currently empty
+        and the selected path exists as a file.
+        """
+        if self._output.get().strip():
+            return
+        img_path: str = self._image.get().strip()
+        if not img_path:
+            return
+        p: Path = Path(img_path)
+        if not p.exists() or not p.is_file():
+            return
+        self._output.set(str(p.parent / ui_sanitize_basename(p.stem)))
 
     def _run_command(self) -> None:
         image: str = self._image.get().strip()

--- a/mkpfs/gui/panels/unpack.py
+++ b/mkpfs/gui/panels/unpack.py
@@ -123,7 +123,7 @@ class UnpackPanel(BasePanel):
         # existing directory (e.g. Desktop -> Desktop/GRIS).
         actual_output: Path = Path(output)
         if actual_output.exists() and actual_output.is_dir() and not self._overwrite.get():
-            actual_output = actual_output / Path(image).stem
+            actual_output = actual_output / ui_sanitize_basename(Path(image).stem)
             self._emit(tr("u_auto_subdir").format(actual_output), "muted")
 
         args: list[str] = ["unpack", image, str(actual_output)]

--- a/mkpfs/utils.py
+++ b/mkpfs/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import tempfile
 from pathlib import Path
 from typing import BinaryIO
@@ -35,6 +36,22 @@ IGNORED_NAMES: frozenset[str] = frozenset(
 def _sanitize_name_component(name: str) -> str:
     """Replace filesystem-unsafe characters in a single name component with ``_``."""
     return "".join(c if (c.isalnum() or c in "._-") else "_" for c in name)
+
+
+def ui_sanitize_basename(name: str) -> str:
+    """Sanitize a name for UI-generated output basenames.
+
+    Replaces a specific set of problematic characters with a single space,
+    collapses consecutive spaces into one, and strips leading/trailing space.
+    This follows the GUI requirement exactly (do NOT convert spaces to
+    underscores).
+    """
+    if not name:
+        return ""
+    # Replace problematic characters with a space.
+    sanitized: str = re.sub(r"[()\[\]\{\}\*\&\^\%\$\#\@!\u00B1\u00A7\|\\\/:;\"'<>,\?]", " ", name)
+    # Collapse runs of whitespace and trim.
+    return " ".join(sanitized.split()).strip()
 
 
 def title_id_from_source(source_root: Path) -> str | None:


### PR DESCRIPTION
# GUI: Auto populate output form fields

## 🤔 Why?
- Users expect sensible defaults when choosing a source — manually typing outputs is slow and error-prone.
- UI-generated filenames may contain problematic characters that cause downstream issues. Providing a sanitized default reduces mistakes.

## 🔧 What changed
- Auto-populate output fields on source selection for these panels (only when the output is empty):
  - Batch: source `/a/b/c` -> output `/a/b/c/converted`
  - Pack folder: `/a/b/c` -> `<parent>/c.ffpfsc` (sanitized)
  - Pack exfat: `/a/b/c` -> `/a/b/c.exfat` (sanitized)
  - Pack file: `/a/b/filename.ext` -> `/a/b/filename.ffpfsc` (sanitized)
  - Unpack: `/a/b/filename.ext` -> `/a/b/filename/` (sanitized)

- Adds `ui_sanitize_basename()` in `mkpfs/utils.py` to replace a set of problematic characters with spaces and collapse duplicate spaces (specifically follows the request — spaces only, no underscores).
- Removes the Version combobox from Batch, Pack Folder, and Pack File UI panels and stops passing `--version` from the UI; the CLI default applies.

## 🧪 How to test (manual)
1. Start the GUI and open the relevant panel.
2. Choose a source path (folder/file) and confirm the Output field auto-fills when it was empty.
3. For Pack Folder/Pack File/exFAT/Unpack, confirm names are sanitized: e.g. `My Game (1)` -> `My Game 1`.
4. Confirm Batch output becomes a `converted` subfolder of the source.
5. Confirm the Pack/Batch/PackFile panels no longer show a Version dropdown and the CLI default handles versioning.

## ✅ Notes
- The sanitizer intentionally replaces problematic characters with spaces and collapses runs of spaces; it does NOT convert spaces to underscores (per the spec).
- All modified GUI panels import cleanly and unit tests run locally (483 passed, 1 skipped) on the working tree.

## 🔖 Labels suggested
- `feature`

---

This file is a suggested PR body. You (or a reviewer) can copy its contents into the PR description to replace or augment the current body.