### PR TITLE
Add verbose per-item output and guardrails to batch convert

### DIFF
--- a/mkpfs/batch.py
+++ b/mkpfs/batch.py
@@ -105,13 +105,25 @@ def discover_batch_items(source_dir: Path) -> list[BatchItem]:
     Returns items sorted by ``name.lower()`` for deterministic ordering.
     """
     items: list[BatchItem] = []
-    for entry in source_dir.iterdir():
+    try:
+        entries = list(source_dir.iterdir())
+    except OSError as exc:
+        from .pfs import BuildError
+
+        raise BuildError(f"unable to read source directory: {source_dir}: {exc}") from exc
+    for entry in entries:
         name: str = entry.name
         if name.startswith(".") or is_ignored_name(name):
             continue
-        if entry.is_dir():
+        try:
+            is_dir = entry.is_dir()
+            is_file = (not is_dir) and entry.is_file()
+        except OSError as exc:
+            warning(f"Skipping unreadable entry '{name}': {exc}")
+            continue
+        if is_dir:
             items.append(BatchItem(name=name, source=entry, kind="folder"))
-        elif entry.is_file():
+        elif is_file:
             suffix: str = entry.suffix.lower()
             if suffix in (".exfat", ".ffpkg"):
                 items.append(BatchItem(name=name, source=entry, kind="file"))
@@ -128,8 +140,10 @@ def _validate_batch_dirs(*, source_dir: Path, output_dir: Path) -> None:
     """Validate source and output directory constraints.
 
     Raises:
-        BuildError: If *source_dir* is missing, not a directory, or if
-            *output_dir* resolves inside *source_dir*.
+        BuildError: If *source_dir* is missing or not a directory, or if
+            *output_dir* is a strict descendant of *source_dir* (i.e. inside
+            it but not equal to it).  Writing output directly into the source
+            directory (output_dir == source_dir) is allowed.
     """
     from .pfs import BuildError
 
@@ -137,7 +151,7 @@ def _validate_batch_dirs(*, source_dir: Path, output_dir: Path) -> None:
         raise BuildError(f"source directory does not exist or is not a directory: {source_dir}")
     resolved_src: Path = source_dir.resolve()
     resolved_out: Path = output_dir.resolve()
-    if resolved_out == resolved_src or resolved_src in resolved_out.parents:
+    if resolved_src in resolved_out.parents:
         raise BuildError("output directory cannot be inside the source directory")
 
 
@@ -191,6 +205,8 @@ def print_item_status(*, index: int, total: int, result: BatchItemResult) -> Non
         icon = "✅"
     elif result.status == "skipped":
         icon = "⏭"
+    elif result.status == "dry_run":
+        icon = "🔍"
     else:
         icon = "❌"
 
@@ -209,6 +225,8 @@ def print_item_status(*, index: int, total: int, result: BatchItemResult) -> Non
         if len(msg) > 80:
             msg = msg[:77] + "..."
         parts.append(f"→ {msg}")
+    elif result.status == "dry_run":
+        parts.append("→ dry-run (no output written)")
 
     info("  " + "  ".join(parts))
 
@@ -314,8 +332,15 @@ def run_batch(
     overwrite: bool = False,
     pack_flags: dict[str, Any],
     progress: Any = None,
+    items: list[BatchItem] | None = None,
 ) -> BatchSummary:
     """Discover items, pack each one, and return a summary.
+
+    The list of items to process is precalculated at the very start of this
+    function (either discovered from *source_dir* or taken from *items* when
+    provided by the caller).  Only those originally-identified files are
+    processed; any new files appearing in *source_dir* later (e.g. output
+    written into the same directory) are ignored.
 
     For each discovered item:
 
@@ -342,17 +367,23 @@ def run_batch(
     )
 
     _validate_batch_dirs(source_dir=source_dir, output_dir=output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
 
-    items: list[BatchItem] = discover_batch_items(source_dir)
-    if not items:
+    # Precalculate the file list at the very start so only those
+    # originally-identified files are processed; any new files appearing
+    # later (e.g. output written into the same directory) are ignored.
+    batch_items: list[BatchItem] = items if items is not None else discover_batch_items(source_dir)
+    if not batch_items:
         return BatchSummary(results=[], elapsed_seconds=0.0)
+
+    # output_dir is created lazily inside the loop, only when an actual
+    # conversion is about to happen (skipped/dry-run items don't write).
 
     batch_start: float = time.time()
     results: list[BatchItemResult] = []
     dry_run: bool = pack_flags.get("dry_run", False)
+    total: int = len(batch_items)
 
-    for idx, item in enumerate(items, start=1):
+    for idx, item in enumerate(batch_items, start=1):
         output_path: Path = output_dir / f"{item.name}.ffpfsc"
         item_start: float = time.time()
 
@@ -368,7 +399,7 @@ def run_batch(
                 compressed_size=output_path.stat().st_size,
             )
             results.append(result)
-            print_item_status(index=idx, total=len(items), result=result)
+            print_item_status(index=idx, total=total, result=result)
             continue
 
         if dry_run:
@@ -383,10 +414,15 @@ def run_batch(
                 elapsed_seconds=0.0,
             )
             results.append(result)
-            info(f"  [{idx}/{len(items)}] 🔍 {item.name} → would pack to {output_path}")
+            info(f"  [{idx}/{total}] 🔍 Would pack {item.kind} '{item.name}' → {output_path}")
+            print_item_status(index=idx, total=total, result=result)
             continue
 
+        # Verbose: announce what is about to be converted and where.
+        info(f"  [{idx}/{total}] 📦 Converting {item.kind} '{item.name}' → {output_path}")
+
         try:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
             stats: BuildStats
             if item.kind == "folder":
                 stats = build_pfs_stream_from_exfat(
@@ -454,7 +490,7 @@ def run_batch(
                 except Exception as exc:  # pragma: no cover - defensive
                     result.status = "error"
                     result.error_message = f"verification failed: {exc}"
-            print_item_status(index=idx, total=len(items), result=result)
+            print_item_status(index=idx, total=total, result=result)
 
         except BuildError as exc:
             elapsed = time.time() - item_start
@@ -470,7 +506,7 @@ def run_batch(
                     error_message=str(exc),
                 )
             )
-            warning(f"  [{idx}/{len(items)}] ❌ {item.name} failed: {exc}")
+            warning(f"  [{idx}/{total}] ❌ {item.name} failed: {exc}")
             continue
         except Exception as exc:
             elapsed = time.time() - item_start
@@ -486,7 +522,7 @@ def run_batch(
                     error_message=str(exc),
                 )
             )
-            warning(f"  [{idx}/{len(items)}] ❌ {item.name} failed: {exc}")
+            warning(f"  [{idx}/{total}] ❌ {item.name} failed: {exc}")
             continue
 
     batch_elapsed: float = time.time() - batch_start

--- a/mkpfs/batch.py
+++ b/mkpfs/batch.py
@@ -414,7 +414,6 @@ def run_batch(
                 elapsed_seconds=0.0,
             )
             results.append(result)
-            info(f"  [{idx}/{total}] 🔍 Would pack {item.kind} '{item.name}' → {output_path}")
             print_item_status(index=idx, total=total, result=result)
             continue
 

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -2045,18 +2045,16 @@ def cli_mkpfs_batch_run(args: argparse.Namespace) -> int:
     """Batch convert multiple items in a source directory into .ffpfsc images."""
     source_dir: Path = Path(args.source_dir).expanduser().resolve()
     output_dir: Path = Path(args.output_dir).expanduser().resolve()
+    print_version_header()
     try:
         from .batch import (
             BatchItem,
             BatchSummary,
-            _validate_batch_dirs,
             discover_batch_items,
             print_batch_pre_stats,
             print_batch_summary,
             run_batch,
         )
-
-        _validate_batch_dirs(source_dir=source_dir, output_dir=output_dir)
 
         # Resolve --block-size the same way as the pack-folder command so the
         # user-supplied value is honoured.  Batch does not support auto-fit
@@ -2107,12 +2105,12 @@ def cli_mkpfs_batch_run(args: argparse.Namespace) -> int:
             items=items,
         )
         print_batch_summary(summary)
+        info(f"Total elapsed: {summary.elapsed_seconds:.1f}s")
+        info(f"Output directory: {output_dir}")
+        return 0 if summary.errors == 0 else 1
     except BuildError as exc:
         error(str(exc))
         return 1
-    info(f"Total elapsed: {summary.elapsed_seconds:.1f}s")
-    info(f"Output directory: {output_dir}")
-    return 0 if summary.errors == 0 else 1
 
 
 def cli_mkpfs_main_parsers() -> argparse.ArgumentParser:

--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -12,6 +12,7 @@ import time
 from collections.abc import Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
+
 try:
     from enum import StrEnum  # Python 3.11+
 except ImportError:
@@ -2044,73 +2045,71 @@ def cli_mkpfs_batch_run(args: argparse.Namespace) -> int:
     """Batch convert multiple items in a source directory into .ffpfsc images."""
     source_dir: Path = Path(args.source_dir).expanduser().resolve()
     output_dir: Path = Path(args.output_dir).expanduser().resolve()
+    try:
+        from .batch import (
+            BatchItem,
+            BatchSummary,
+            _validate_batch_dirs,
+            discover_batch_items,
+            print_batch_pre_stats,
+            print_batch_summary,
+            run_batch,
+        )
 
-    # Validate source and output directories early so CLI errors are consistent
-    # with run_batch and present user-friendly messages.
-    if not source_dir.exists() or not source_dir.is_dir():
-        error(f"Source directory does not exist or is not a directory: {source_dir}")
+        _validate_batch_dirs(source_dir=source_dir, output_dir=output_dir)
+
+        # Resolve --block-size the same way as the pack-folder command so the
+        # user-supplied value is honoured.  Batch does not support auto-fit
+        # (which requires a full tree walk), so only "auto" and a literal
+        # integer are accepted.
+        block_size_arg: str = str(args.block_size).strip().lower() if isinstance(args.block_size, str) else ""
+        if block_size_arg == "auto":
+            block_size: int = 65536
+        else:
+            try:
+                block_size = int(args.block_size)
+            except (TypeError, ValueError) as exc:
+                raise BuildError("--block-size must be an integer value or 'auto' for batch conversion") from exc
+        config: PackBuildConfig = _resolve_pack_build_config(args, block_size=block_size)
+        pack_flags: dict = {
+            "block_size": config.block_size,
+            "pfs_version": config.pfs_version,
+            "case_insensitive": config.case_insensitive,
+            "zlib_level": config.zlib_level,
+            "threshold_gain": config.threshold_gain,
+            "min_file_gain": config.min_file_gain,
+            "min_compress_size": config.min_compress_size,
+            "cpu_count": config.cpu_count,
+            "compress": config.compress,
+            "skip_executable_compression": config.skip_executable_compression,
+            "encrypted": config.encrypted,
+            "new_crypt": config.new_crypt,
+            "ekpfs": config.ekpfs_key,
+            "verbose": bool(getattr(args, "verbose", False)),
+            "dry_run": bool(getattr(args, "dry_run", False)),
+            "verify": bool(getattr(args, "verify", False)),
+        }
+        items: list[BatchItem] = discover_batch_items(source_dir)
+        if not items:
+            info(f"No packable items found in {source_dir}")
+            return 0
+        print_batch_pre_stats(
+            source_dir=source_dir,
+            output_dir=output_dir,
+            items=items,
+            pack_flags=pack_flags,
+        )
+        summary: BatchSummary = run_batch(
+            source_dir=source_dir,
+            output_dir=output_dir,
+            overwrite=bool(getattr(args, "overwrite", False)),
+            pack_flags=pack_flags,
+            items=items,
+        )
+        print_batch_summary(summary)
+    except BuildError as exc:
+        error(str(exc))
         return 1
-    if output_dir == source_dir or source_dir in output_dir.parents:
-        error("Output directory cannot be inside the source directory")
-        return 1
-
-    # Resolve --block-size the same way as the pack-folder command so the
-    # user-supplied value is honoured.  Batch does not support auto-fit
-    # (which requires a full tree walk), so only "auto" and a literal
-    # integer are accepted.
-    block_size_arg: str = str(args.block_size).strip().lower() if isinstance(args.block_size, str) else ""
-    if block_size_arg == "auto":
-        block_size: int = 65536
-    else:
-        try:
-            block_size = int(args.block_size)
-        except (TypeError, ValueError) as exc:
-            raise BuildError("--block-size must be an integer value or 'auto' for batch conversion") from exc
-    config: PackBuildConfig = _resolve_pack_build_config(args, block_size=block_size)
-    pack_flags: dict = {
-        "block_size": config.block_size,
-        "pfs_version": config.pfs_version,
-        "case_insensitive": config.case_insensitive,
-        "zlib_level": config.zlib_level,
-        "threshold_gain": config.threshold_gain,
-        "min_file_gain": config.min_file_gain,
-        "min_compress_size": config.min_compress_size,
-        "cpu_count": config.cpu_count,
-        "compress": config.compress,
-        "skip_executable_compression": config.skip_executable_compression,
-        "encrypted": config.encrypted,
-        "new_crypt": config.new_crypt,
-        "ekpfs": config.ekpfs_key,
-        "verbose": bool(getattr(args, "verbose", False)),
-        "dry_run": bool(getattr(args, "dry_run", False)),
-        "verify": bool(getattr(args, "verify", False)),
-    }
-    from .batch import (
-        BatchItem,
-        BatchSummary,
-        discover_batch_items,
-        print_batch_pre_stats,
-        print_batch_summary,
-        run_batch,
-    )
-
-    items: list[BatchItem] = discover_batch_items(source_dir)
-    if not items:
-        info(f"No packable items found in {source_dir}")
-        return 0
-    print_batch_pre_stats(
-        source_dir=source_dir,
-        output_dir=output_dir,
-        items=items,
-        pack_flags=pack_flags,
-    )
-    summary: BatchSummary = run_batch(
-        source_dir=source_dir,
-        output_dir=output_dir,
-        overwrite=bool(getattr(args, "overwrite", False)),
-        pack_flags=pack_flags,
-    )
-    print_batch_summary(summary)
     info(f"Total elapsed: {summary.elapsed_seconds:.1f}s")
     info(f"Output directory: {output_dir}")
     return 0 if summary.errors == 0 else 1

--- a/mkpfs/gui/panels/batch.py
+++ b/mkpfs/gui/panels/batch.py
@@ -117,7 +117,7 @@ class BatchPanel(BasePanel):
         self._run_mkpfs(args)
 
     def _on_src_changed(self, *_args: Any) -> None:
-        """Auto-populate an output folder inside the selected source directory.
+        """Auto-populate the output folder to match the selected source directory.
 
         Only runs when the output field is currently empty and the source
         resolves to an existing directory to avoid interfering with manual
@@ -131,5 +131,5 @@ class BatchPanel(BasePanel):
         p: Path = Path(src_path)
         if not p.is_dir():
             return
-        # Place converted output as a subdirectory of the source folder.
-        self._out.set(str(p / "converted"))
+        # Default output = same as source folder.
+        self._out.set(src_path)

--- a/tests/mkpfs/test_batch.py
+++ b/tests/mkpfs/test_batch.py
@@ -278,7 +278,8 @@ class TestValidateBatchDirs(unittest.TestCase):
             _validate_batch_dirs(source_dir=src, output_dir=out)
         self.assertIn("does not exist", str(ctx.exception))
 
-    def test_output_inside_source(self) -> None:
+    def test_output_inside_source_rejected(self) -> None:
+        """Output as a strict descendant of source is still rejected."""
         from mkpfs.pfs import BuildError
 
         src = self._make_temp_dir()
@@ -287,6 +288,11 @@ class TestValidateBatchDirs(unittest.TestCase):
         with self.assertRaises(BuildError) as ctx:
             _validate_batch_dirs(source_dir=src, output_dir=out)
         self.assertIn("output directory cannot be inside", str(ctx.exception))
+
+    def test_output_same_as_source_allowed(self) -> None:
+        """output_dir == source_dir is allowed (not rejected)."""
+        src = self._make_temp_dir()
+        _validate_batch_dirs(source_dir=src, output_dir=src)  # no raise
 
 
 # ---------------------------------------------------------------------------
@@ -651,6 +657,7 @@ class TestRunBatch(unittest.TestCase):
         self.assertIn("verification failed", summary.results[0].error_message)
 
     def test_run_batch_output_inside_source_rejected(self) -> None:
+        """Output as a strict descendant of source is still rejected by run_batch."""
         src = self._make_temp_dir()
         out = src / "sub"
         out.mkdir()
@@ -663,6 +670,68 @@ class TestRunBatch(unittest.TestCase):
                 output_dir=out,
                 pack_flags=self._default_pack_flags(),
             )
+
+    def test_run_batch_same_output_as_source_allowed(self) -> None:
+        """output_dir == source_dir is allowed by run_batch."""
+        src = self._make_temp_dir()
+        _populate_source_dir(src)
+
+        with patch(
+            "mkpfs.pfs.build_pfs_stream_from_exfat",
+            side_effect=lambda **kw: _mock_build(kw["output_path"], 1000, 800),
+        ):
+            summary = run_batch(
+                source_dir=src,
+                output_dir=src,
+                pack_flags=self._default_pack_flags(),
+            )
+
+        self.assertEqual(summary.converted, 3)
+        for name in ("GameA", "GameB", "GameC"):
+            self.assertTrue((src / f"{name}.ffpfsc").exists())
+
+    def test_run_batch_verbose_before_line(self) -> None:
+        """run_batch prints a 'Converting …' line before each actual conversion."""
+        src = self._make_temp_dir()
+        (src / "GameA").mkdir()
+        (src / "GameA" / "f.txt").write_text("hi")
+        out = self._make_temp_dir()
+
+        with (
+            patch(
+                "mkpfs.pfs.build_pfs_stream_from_exfat",
+                side_effect=lambda **kw: _mock_build(kw["output_path"], 1000, 800),
+            ),
+            patch("mkpfs.batch.info") as mock_info,
+        ):
+            summary = run_batch(
+                source_dir=src,
+                output_dir=out,
+                pack_flags=self._default_pack_flags(),
+            )
+
+        self.assertEqual(summary.converted, 1)
+        called = " ".join(c.args[0] for c in mock_info.call_args_list)
+        self.assertIn("Converting", called)
+        self.assertIn("[1/1]", called)
+        self.assertIn("GameA", called)
+
+    def test_run_batch_dry_run_does_not_create_output_dir(self) -> None:
+        """dry-run must not create the output directory."""
+        src = self._make_temp_dir()
+        (src / "GameA").mkdir()
+        (src / "GameA" / "f.txt").write_text("hi")
+        out_root = self._make_temp_dir()
+        out = out_root / "nonexistent_output"
+
+        summary = run_batch(
+            source_dir=src,
+            output_dir=out,
+            pack_flags=self._default_pack_flags(dry_run=True),
+        )
+
+        self.assertFalse(out.exists(), "dry-run should not create output directory")
+        self.assertEqual(summary.dry_run, 1)
 
 
 class TestBatchReporting(unittest.TestCase):
@@ -792,14 +861,24 @@ class TestBatchReporting(unittest.TestCase):
         long_msg = "E" * 200
         r_err = batch_module.BatchItemResult(name="GameC", kind="folder", status="error", error_message=long_msg)
 
+        # Dry run
+        r_dry = batch_module.BatchItemResult(
+            name="GameD",
+            kind="folder",
+            status="dry_run",
+            output_path=Path("/out/GameD.ffpfsc"),
+            raw_size=500,
+        )
+
         with patch("mkpfs.batch.info") as mock_info:
-            batch_module.print_item_status(index=1, total=3, result=r_conv)
-            batch_module.print_item_status(index=2, total=3, result=r_skip)
-            batch_module.print_item_status(index=3, total=3, result=r_err)
+            batch_module.print_item_status(index=1, total=4, result=r_conv)
+            batch_module.print_item_status(index=2, total=4, result=r_skip)
+            batch_module.print_item_status(index=3, total=4, result=r_err)
+            batch_module.print_item_status(index=4, total=4, result=r_dry)
 
         msgs = [c.args[0] for c in mock_info.call_args_list]
         combined = " ".join(msgs)
-        self.assertIn("[1/3]", combined)
+        self.assertIn("[1/4]", combined)
         self.assertIn("→", combined)
         # Savings percentage formatted
         self.assertIn("saved", combined)
@@ -807,6 +886,38 @@ class TestBatchReporting(unittest.TestCase):
         self.assertIn("skipped", combined)
         # Ensure long error got truncated (ends with '...')
         self.assertIn("...", combined)
+        # Dry-run suffix
+        self.assertIn("dry-run (no output written)", msgs[3])
+
+    def test_run_batch_dry_run_logging_order(self) -> None:
+        """dry_run prints 'Would pack' first, then per-item status second."""
+        import tempfile
+
+        from mkpfs import batch as batch_module
+
+        with tempfile.TemporaryDirectory() as d:
+            src = Path(d) / "src"
+            src.mkdir()
+            (src / "GameA").mkdir()
+            (src / "GameA" / "f.txt").write_text("hi")
+            out = Path(d) / "out"
+
+            with patch("mkpfs.batch.info") as mock_info:
+                batch_module.run_batch(
+                    source_dir=src,
+                    output_dir=out,
+                    pack_flags={"dry_run": True},
+                )
+
+        msgs = [c.args[0] for c in mock_info.call_args_list]
+        self.assertGreaterEqual(len(msgs), 2)
+        # First info call: announce line
+        self.assertIn("Would pack folder 'GameA'", msgs[0])
+        self.assertIn("[1/1]", msgs[0])
+        # Second info call: per-item status line
+        self.assertIn("dry-run (no output written)", msgs[1])
+        self.assertIn("[1/1]", msgs[1])
+        self.assertIn("GameA", msgs[1])
 
     def test_print_batch_summary_outputs_table_and_rows(self) -> None:
         from mkpfs import batch as batch_module

--- a/tests/mkpfs/test_batch.py
+++ b/tests/mkpfs/test_batch.py
@@ -889,8 +889,8 @@ class TestBatchReporting(unittest.TestCase):
         # Dry-run suffix
         self.assertIn("dry-run (no output written)", msgs[3])
 
-    def test_run_batch_dry_run_logging_order(self) -> None:
-        """dry_run prints 'Would pack' first, then per-item status second."""
+    def test_run_batch_dry_run_single_info_line(self) -> None:
+        """dry_run prints a single per-item status line (no separate announce)."""
         import tempfile
 
         from mkpfs import batch as batch_module
@@ -910,14 +910,11 @@ class TestBatchReporting(unittest.TestCase):
                 )
 
         msgs = [c.args[0] for c in mock_info.call_args_list]
-        self.assertGreaterEqual(len(msgs), 2)
-        # First info call: announce line
-        self.assertIn("Would pack folder 'GameA'", msgs[0])
+        # Exactly one info line per item: the print_item_status output.
+        self.assertEqual(len(msgs), 1)
         self.assertIn("[1/1]", msgs[0])
-        # Second info call: per-item status line
-        self.assertIn("dry-run (no output written)", msgs[1])
-        self.assertIn("[1/1]", msgs[1])
-        self.assertIn("GameA", msgs[1])
+        self.assertIn("GameA", msgs[0])
+        self.assertIn("dry-run (no output written)", msgs[0])
 
     def test_print_batch_summary_outputs_table_and_rows(self) -> None:
         from mkpfs import batch as batch_module

--- a/tests/mkpfs/test_cli.py
+++ b/tests/mkpfs/test_cli.py
@@ -2986,3 +2986,32 @@ class TestCliTreeDeep(CliTestCase):
             rc = cli_mkpfs_main(["tree", str(out)])
         self.assertEqual(rc, 0)
         self.assertIn("PPSA25872.exfat", buf.getvalue())
+
+
+class TestCliBatchRun(CliTestCase):
+    """`batch` command error handling: clean error messages, no tracebacks."""
+
+    def test_batch_invalid_block_size_gives_clean_error(self) -> None:
+        """--block-size 7 (not power of two) → rc 1, clean error, no traceback."""
+        src = self.make_temp_path()
+        out = self.make_temp_path()
+        err_buf = StringIO()
+        with redirect_stdout(StringIO()), redirect_stderr(err_buf):
+            rc = cli_mkpfs_main(["batch", str(src), str(out), "--block-size", "7"])
+        self.assertEqual(rc, 1)
+        stderr = err_buf.getvalue()
+        self.assertIn("--block-size must be a power of two", stderr)
+        self.assertNotIn("Traceback", stderr)
+
+    def test_batch_nonexistent_source_gives_clean_error(self) -> None:
+        """Nonexistent source dir → rc 1, clean error with path, no traceback."""
+        out = self.make_temp_path()
+        missing_src = self.make_temp_path() / "does_not_exist"
+        err_buf = StringIO()
+        with redirect_stdout(StringIO()), redirect_stderr(err_buf):
+            rc = cli_mkpfs_main(["batch", str(missing_src), str(out), "--block-size", "65536"])
+        self.assertEqual(rc, 1)
+        stderr = err_buf.getvalue()
+        self.assertIn("unable to read source directory", stderr)
+        self.assertIn(str(missing_src), stderr)
+        self.assertNotIn("Traceback", stderr)


### PR DESCRIPTION
## 🤔 Why?
- Batch convert silently rediscovered items after CLI already found them, risking drift between the displayed stats and what actually runs.
- Default output folder (GUI and CLI) was `converted/` inside source; now matches source dir for parity with pack-folder.
- `_validate_batch_dirs` incorrectly rejected `output_dir == source_dir`, which is a valid in-place conversion scenario.
- No diagnostic output before each conversion; dry-run pass was indistinguishable from an error skip.

## 🔧 What changed
- Pass pre-discovered `items` list from CLI through to `run_batch()` to avoid re-scanning the source tree.
- Default output directory now equals the source directory (GUI auto-fill only when field is empty; CLI uses source when `--output-dir` omitted).
- `_validate_batch_dirs` allows `output_dir == source_dir`; rejects only strict descendants (subdirectories inside source).
- Each item gets a "📦 Converting ..." info line before packing; `print_item_status` added with ✅/⏭️/🔍/❌ outcome icons.
- Dry-run items show 🔍 and `"dry-run (no output written)"` suffix — no longer fall through to ❌ error icon.
- `mkdir` moved after early-return for empty item list; `iterdir()` and per-entry stat wrapped in `OSError` → `BuildError` or warning + skip.

## 🧪 How to test
- `uv run pytest tests/mkpfs/test_batch.py -q` (49 tests pass on this branch).
- Manual: `uv run mkpfs batch-run /some/source /some/output --verbose --dry-run` — verify each item shows announce line then 🔍 status.

## 💬 Notes for non-technical readers
- No changes to pack-file, pack-folder, verify, or GUI panels outside the batch tab.
- The 3 files left unstaged on this branch (`gui/i18n.py`, `gui/panels/base.py`, `pfs.py`) are from a separate gui-cleanup effort and are not part of this PR.