### PR TITLE
Use native monospaced font on macOS and Linux

### DIFF
--- a/mkpfs/gui/theme.py
+++ b/mkpfs/gui/theme.py
@@ -1,5 +1,7 @@
 """Neon glassmorphism theme constants for the mkpfs GUI."""
 
+import sys
+
 # Backgrounds — deep space
 _BG_DEEP = "#0B0E17"  # deepest background
 _BG_PANEL = "#121626"  # card / panel body
@@ -28,7 +30,10 @@ _WARNING = _NEON_AMBER
 # UI constants
 _SIDEBAR_W: int = 210
 _CORNER: int = 14
-_FONT_MONO = ("Consolas", 12)
+_MONO_FAMILY: str = (
+    "Consolas" if sys.platform.startswith("win") else "Menlo" if sys.platform == "darwin" else "DejaVu Sans Mono"
+)
+_FONT_MONO = (_MONO_FAMILY, 12)
 _FONT_UI = ("Segoe UI", 13)
 _FONT_LABEL = ("Segoe UI", 11)
 _FONT_SMALL = ("Segoe UI", 10)


### PR DESCRIPTION
## 🤔 Why?

The GUI log panel and several other panels used only Consolas, a Windows-only monospaced font. On macOS and Linux the fallback was undefined, resulting in the default proportional font — hard to read terminal-style output.

## 🔧 What changed

- `_FONT_MONO` now picks the correct native monospaced font per platform: Consolas (Windows), Menlo (macOS), or DejaVu Sans Mono (Linux).
- Change is in one file — all panels that reference the constant pick it up automatically.

## 🧪 How to test

Launch the GUI on macOS or Linux and check the output log panel — text should render in a clean monospaced font.