### PR TITLE
Fix GUI window freeze on Windows during operations

### DIFF
--- a/mkpfs/gui/__main__.py
+++ b/mkpfs/gui/__main__.py
@@ -8,8 +8,25 @@ uses relative imports that fail in a frozen context where the file is executed a
 from __future__ import annotations
 
 import multiprocessing
+import sys
 
+# Important on Windows: ensure multiprocessing-spawned children are handled
+# before we decide which entrypoint to take.
 multiprocessing.freeze_support()
+
+# Lightweight router:
+# - Normal launch → start the GUI (imports heavy GUI stack only on this path)
+# - Special marker ``--gui-subprocess`` → run the CLI inside this same frozen
+#   binary so the GUI can spawn a child process, stream its stdout/stderr, and
+#   retain a handle for cancellation.  The marker is checked *after*
+#   ``freeze_support()`` so multiprocessing-spawned children never take this
+#   branch.
+if "--gui-subprocess" in sys.argv:
+    idx: int = sys.argv.index("--gui-subprocess")
+    cli_args: list[str] = sys.argv[idx + 1 :]
+    from mkpfs.cli import cli_mkpfs_main
+
+    raise SystemExit(int(cli_mkpfs_main(cli_args)))
 
 from mkpfs.gui.app import main  # ruff: ignore[module-import-not-at-top-of-file]
 

--- a/mkpfs/gui/panels/base.py
+++ b/mkpfs/gui/panels/base.py
@@ -390,6 +390,8 @@ class BasePanel(ctk.CTkFrame):
                 proc.stdin.write("y\n")
                 proc.stdin.close()
             except (BrokenPipeError, OSError):
+                # Child already closed stdin (e.g. crashed before reading);
+                # nothing to recover — streaming will surface the error.
                 pass
 
         # Stream child stdout/stderr line by line through the log pane.

--- a/mkpfs/gui/panels/base.py
+++ b/mkpfs/gui/panels/base.py
@@ -1,16 +1,14 @@
 """Base panel class for the mkpfs GUI operation panels."""
 
-import builtins
-import contextlib
-import io
 import queue
+import subprocess
+import sys
 import threading
 from tkinter import filedialog
 from typing import Any
 
 import customtkinter as ctk
 
-from ... import pbar as _pbar
 from ..i18n import tr
 from ..theme import (
     _BG_CARD,
@@ -67,6 +65,7 @@ class BasePanel(ctk.CTkFrame):
         self._accent: str = _PANEL_ACCENT.get(self._panel_key, _NEON_BLUE)
         self._last_phase: str = ""
         self._last_progress: tuple[int, int] = (0, 0)
+        self._proc: subprocess.Popen | None = None
 
         # Header
         header: ctk.CTkFrame = ctk.CTkFrame(self, fg_color="transparent")
@@ -340,100 +339,88 @@ class BasePanel(ctk.CTkFrame):
         self._log_queue.put((tag, text))
 
     def _run_mkpfs(self, args: list[str]) -> None:
-        """Run mkpfs in-process and stream each output line to the log pane.
+        r"""Run mkpfs as a child process and stream each output line to the log pane.
 
-        Executes ``cli_mkpfs_main`` directly in the current Python interpreter
-        (the same one running the GUI) so no venv discovery or subprocess
-        spawning is required.  ``sys.stdout`` / ``sys.stderr`` are temporarily
-        redirected to a line-streaming helper that emits each line to the log
-        queue as it arrives.  ``builtins.input`` is patched to auto-confirm the
-        overwrite prompt with "y" so the GUI never blocks waiting for stdin.
+        The CLI runs in a separate process (``sys.executable --gui-subprocess …``)
+        rather than in-process so the GUI's drawing thread is never blocked by
+        long-running compression/multiprocessing work.  The spawned process handle
+        is stored on ``self._proc`` so a future stop button can call
+        ``terminate()``.
+
+        On Windows a console-window flash is suppressed via
+        ``CREATE_NO_WINDOW``.  ``stdin`` is fed ``"y\\n"`` so any
+        ``Overwrite? [Y/n]`` prompt is auto-confirmed (matching the previous
+        in-process ``builtins.input`` patch).  Progress-bar determinate mode is
+        not available across a process boundary; the log pane still shows all
+        output.
 
         Args:
-            args: CLI argument list passed verbatim to ``cli_mkpfs_main``.
+            args: CLI argument list passed verbatim to the CLI entrypoint.
         """
-        # Late import -- if mkpfs or its dependencies are missing the
-        # ImportError is caught below and shown as a readable error message.
-        try:
-            from mkpfs.cli import cli_mkpfs_main
-        except ImportError as exc:
-            self._emit(f"✗ Cannot import mkpfs: {exc}", "error")
-            self._emit("   Ensure cryptography is installed: uv sync", "muted")
-            return
-
         self._emit(f"$ mkpfs {' '.join(args)}", "muted")
 
-        # Line-streaming writer that forwards each line to the log queue.
-        emit: Any = self._emit
+        # Build the subprocess invocation.  ``--gui-subprocess`` tells the
+        # frozen entry point (mkpfs/gui/__main__.py) to route to the CLI instead
+        # of the GUI; everything after it is passed to ``cli_mkpfs_main``.
+        cmd: list[str] = [sys.executable, "--gui-subprocess", *args]
 
-        class _Streamer(io.TextIOBase):
-            def __init__(self, tag_fn: Any) -> None:
-                self._tag_fn: Any = tag_fn
-                self._buf: str = ""
+        # On Windows, suppress the console-window flash that subprocess.Popen
+        # would otherwise create for every operation (visible regression under
+        # a --windowed PyInstaller build).  Harmless on the frozen windowed exe;
+        # essential in dev mode where sys.executable is python.exe (console).
+        popen_kwargs: dict[str, Any] = {
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.STDOUT,
+            "stdin": subprocess.PIPE,
+            "text": True,
+        }
+        if sys.platform == "win32":
+            popen_kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
 
-            def write(self, s: str) -> int:
-                self._buf += s
-                # Process complete lines (delimited by \n). Within each line,
-                # \r means "overwrite the current line" so only the content
-                # after the last \r is kept — matching terminal semantics.
-                while "\n" in self._buf:
-                    line, self._buf = self._buf.split("\n", 1)
-                    # \r overwrites: keep only what's after the last \r
-                    if "\r" in line:
-                        line = line.rsplit("\r", 1)[1]
-                    stripped: str = line.rstrip()
-                    if not stripped:
-                        continue
-                    lower: str = stripped.lower()
-                    tag: str = ""
-                    # Match error prefix (❌ / ERROR ) not substring so "Errors: 0"
-                    # doesn't falsely set the failed flag on success.
-                    if lower.startswith(("\u2713", "done:", "complete:", "success:")):
-                        tag = "success"
-                    elif lower.startswith("error ") or "\u274c" in stripped:
-                        tag = "error"
-                    elif lower.startswith("warn ") or "\u26a0" in stripped:
-                        tag = "warning"
-                    self._tag_fn(stripped, tag)
-                return len(s)
-
-            def flush(self) -> None:
-                # Emit any remaining buffered content on flush so the final
-                # progress state appears in the log before completion.
-                if self._buf.strip():
-                    stripped: str = self._buf.rstrip()
-                    self._buf = ""
-                    lower: str = stripped.lower()
-                    tag: str = ""
-                    if lower.startswith(("\u2713", "done:", "complete:", "success:")):
-                        tag = "success"
-                    elif lower.startswith("error ") or "\u274c" in stripped:
-                        tag = "error"
-                    elif lower.startswith("warn ") or "\u26a0" in stripped:
-                        tag = "warning"
-                    self._tag_fn(stripped, tag)
-
-        streamer: _Streamer = _Streamer(emit)
-        original_input: Any = builtins.input
-        exit_code: int = 0
-
-        # Install a context-local default listener for this execution.
-        # Using a ContextVar avoids a global swap race between threads.
-        token = _pbar.default_listener.set(self._queued_progress)
-
-        # Auto-confirm any "Overwrite? [Y/n]" prompts from the CLI.
-        builtins.input = lambda _prompt="": "y"
         try:
-            with contextlib.redirect_stdout(streamer), contextlib.redirect_stderr(streamer):
-                exit_code = int(cli_mkpfs_main(args))
-        except SystemExit as exc:
-            exit_code = int(exc.code) if exc.code is not None else 0
-        except Exception as exc:
-            self._emit(f"✗ Unexpected error: {exc}", "error")
+            proc: subprocess.Popen = subprocess.Popen(cmd, **popen_kwargs)
+        except OSError as exc:
+            self._emit(f"✗ Failed to start mkpfs: {exc}", "error")
             return
+        self._proc = proc
+        # Auto-confirm any "Overwrite? [Y/n]" prompt from the CLI by piping
+        # "y\n" to the child's stdin, then close it so the child sees EOF.
+        if proc.stdin is not None:
+            try:
+                proc.stdin.write("y\n")
+                proc.stdin.close()
+            except (BrokenPipeError, OSError):
+                pass
+
+        # Stream child stdout/stderr line by line through the log pane.
+        assert proc.stdout is not None
+        try:
+            line: str
+            for line in proc.stdout:
+                # ``\r`` overwrites: keep only the content after the last ``\r``
+                # (terminal progress semantics) so the log pane doesn't
+                # accumulate incremental progress bars.
+                if "\r" in line:
+                    line = line.rsplit("\r", 1)[1]
+                stripped: str = line.rstrip()
+                if not stripped:
+                    continue
+                lower: str = stripped.lower()
+                tag: str = ""
+                # Match error prefix (❌ / ERROR ) not substring so "Errors: 0"
+                # doesn't falsely set the failed flag on success.
+                if lower.startswith(("\u2713", "done:", "complete:", "success:")):
+                    tag = "success"
+                elif lower.startswith("error ") or "\u274c" in stripped:
+                    tag = "error"
+                elif lower.startswith("warn ") or "\u26a0" in stripped:
+                    tag = "warning"
+                self._emit(stripped, tag)
         finally:
-            builtins.input = original_input
-            _pbar.default_listener.reset(token)
+            proc.wait()
+            self._proc = None
+
+        exit_code: int = int(proc.returncode or 0)
         self._emit("", "")
         if exit_code == 0:
             self._emit(tr("ok"), "success")


### PR DESCRIPTION
## 🤔 Why?

On Windows, starting any operation (pack folder, pack file, verify) made the entire GUI window freeze — "Not responding" in the title bar until the command finished. The window couldn't be moved or interacted with.

The root cause: `multiprocessing.Pool` uses `spawn` on Windows, which re-imports `__main__` in each child process. When this happens from a non-main thread inside a `--windowed` PyInstaller binary, the spawn handshake blocks the Windows message pump. macOS uses `fork` and was never affected.

## 🔧 What changed

- Replaced the in-process `cli_mkpfs_main()` call in `BasePanel._run_mkpfs` with a `subprocess.Popen` child that streams output back to the log pane
- Added a `--gui-subprocess` router in `mkpfs/gui/__main__.py` so the frozen binary runs the CLI instead of the GUI when the marker is present
- Stored the `Popen` handle on `self._proc` for a future stop/cancel button
- Suppressed Windows console-window flash with `CREATE_NO_WINDOW` (essential for dev mode, harmless on frozen exe)
- Auto-confirmed overwrite prompts by piping `"y\n"` to stdin (replacing the old `builtins.input` patch)

## 🧪 How to test

```bash
# Verify the subprocess routing works (dev mode):
python -m mkpfs.gui --gui-subprocess -V

# Run full test suite:
bash run-tests.sh
```

## 💬 Notes

- The progress bar becomes indeterminate across the process boundary (detectable phase progress is not available), but the log pane still streams all output in real time
- The change is minimal and focused on the threading fix; no other panel code or behavior is affected
- Closes #120