### PR TITLE
Fix Windows crash on GUI success logs

### DIFF
--- a/mkpfs/cli.py
+++ b/mkpfs/cli.py
@@ -1637,7 +1637,7 @@ def _run_stream_pack_file(*, args: argparse.Namespace, source_file: Path) -> int
             hide_headers=True,
         )
         if rc == 0:
-            info("🎉 Image created successfully!")
+            info("Image created successfully!", icon_name="success")
         return rc
 
 

--- a/mkpfs/gui/__main__.py
+++ b/mkpfs/gui/__main__.py
@@ -8,8 +8,25 @@ uses relative imports that fail in a frozen context where the file is executed a
 from __future__ import annotations
 
 import multiprocessing
+import sys
 
+# Important on Windows: ensure multiprocessing-spawned children are handled
+# before we decide which entrypoint to take.
 multiprocessing.freeze_support()
+
+# Lightweight router:
+# - Normal launch → start the GUI (imports heavy GUI stack only on this path)
+# - Special marker ``--gui-subprocess`` → run the CLI inside this same frozen
+#   binary so the GUI can spawn a child process, stream its stdout/stderr, and
+#   retain a handle for cancellation.  The marker is checked *after*
+#   ``freeze_support()`` so multiprocessing-spawned children never take this
+#   branch.
+if "--gui-subprocess" in sys.argv:
+    idx: int = sys.argv.index("--gui-subprocess")
+    cli_args: list[str] = sys.argv[idx + 1 :]
+    from mkpfs.cli import cli_mkpfs_main
+
+    raise SystemExit(int(cli_mkpfs_main(cli_args)))
 
 from mkpfs.gui.app import main  # ruff: ignore[module-import-not-at-top-of-file]
 

--- a/mkpfs/gui/__main__.py
+++ b/mkpfs/gui/__main__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import multiprocessing
 import sys
+from contextlib import suppress
 
 # Important on Windows: ensure multiprocessing-spawned children are handled
 # before we decide which entrypoint to take.
@@ -22,6 +23,11 @@ multiprocessing.freeze_support()
 #   ``freeze_support()`` so multiprocessing-spawned children never take this
 #   branch.
 if "--gui-subprocess" in sys.argv:
+    # Force UTF-8 on stdout/stderr so piped output on Windows (where the
+    # OEM code page is cp1252) does not crash on non-ASCII glyphs.
+    for _stream in (sys.stdout, sys.stderr):
+        with suppress(AttributeError, OSError):
+            _stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
     idx: int = sys.argv.index("--gui-subprocess")
     cli_args: list[str] = sys.argv[idx + 1 :]
     from mkpfs.cli import cli_mkpfs_main

--- a/mkpfs/gui/panels/base.py
+++ b/mkpfs/gui/panels/base.py
@@ -1,7 +1,6 @@
 """Base panel class for the mkpfs GUI operation panels."""
 
 import queue
-import re
 import subprocess
 import sys
 import threading
@@ -24,8 +23,6 @@ from ..widgets import GlassCard, LogPane, NeonButton, SectionLabel
 # ---------------------------------------------------------------------------
 # Panel base class
 # ---------------------------------------------------------------------------
-# Matches pbar.py progress lines: [##########----------] N% phase
-_PROGRESS_RE: re.Pattern[str] = re.compile(r"^\[[#-]+\]\s*(\d+)%\s*(\S+)")
 
 
 class BasePanel(ctk.CTkFrame):
@@ -203,21 +200,7 @@ class BasePanel(ctk.CTkFrame):
         try:
             while True:
                 tag, text = self._log_queue.get_nowait()
-                if tag == "__progress__":
-                    # Progress update from subprocess: format "pct\tphase"
-                    parts: list[str] = text.split("\t", 1)
-                    pct: int = int(parts[0]) if parts and parts[0] else 0
-                    phase: str = parts[1] if len(parts) > 1 else ""
-                    if self._progress.cget("mode") != "determinate":
-                        self._progress.stop()
-                        self._progress.configure(mode="determinate")
-                        self._progress.set(0)
-                    self._progress.set(max(0.0, min(1.0, pct / 100.0)))
-                    if phase:
-                        self._phase_label.configure(text=phase)
-                    self._last_phase = phase
-                    self._last_progress = (pct, 100)
-                elif tag == "error":
+                if tag == "error":
                     self._failed = True
                     self._log.append(text, tag)
                 elif tag == "__done__":
@@ -230,11 +213,6 @@ class BasePanel(ctk.CTkFrame):
                         self._progress.set(0)
                         self._phase_label.configure(text="")
                     else:
-                        # Emit a final log line for the last completed phase
-                        if self._last_phase:
-                            prev_done, prev_total = self._last_progress
-                            pct: int = int(prev_done / prev_total * 100) if prev_total > 0 else 100
-                            self._log.append(f"✓ {self._last_phase}: {pct}%", "success")
                         # Freeze progress bar at 100% and show completion label briefly
                         self._progress.stop()
                         self._progress.configure(mode="determinate")
@@ -318,29 +296,17 @@ class BasePanel(ctk.CTkFrame):
         """
         self._emit(f"$ mkpfs {' '.join(args)}", "muted")
 
-        # Build the subprocess invocation.  In a frozen PyInstaller binary
-        # ``sys.executable`` is the binary itself and ``--gui-subprocess`` lands
-        # in ``sys.argv``; in dev mode ``sys.executable`` is the interpreter and
-        # we route through ``-m mkpfs.gui`` to hit ``__main__.py``.
-        if getattr(sys, "frozen", False):
-            cmd: list[str] = [sys.executable, "--gui-subprocess", *args]
-        else:
-            cmd = [sys.executable, "-m", "mkpfs.gui", "--gui-subprocess", *args]
-
-        # ``text=True`` enables universal newlines (``\r`` → ``\n``) so each
-        # progress-bar tick becomes its own line.  ``encoding="utf-8"`` ensures
-        # non-ASCII output decodes cleanly on all platforms.
+        # ``text=True`` enables universal newlines; stderr merged into stdout.
+        # Build subprocess command for CLI execution
+        cmd: list[str] = [sys.executable, "--gui-subprocess", *args]
         popen_kwargs: dict[str, Any] = {
             "stdout": subprocess.PIPE,
             "stderr": subprocess.STDOUT,
             "stdin": subprocess.PIPE,
             "text": True,
-            "encoding": "utf-8",
-            "errors": "replace",
         }
         if sys.platform == "win32":
             popen_kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
-
         try:
             proc: subprocess.Popen = subprocess.Popen(cmd, **popen_kwargs)
         except OSError as exc:
@@ -357,24 +323,18 @@ class BasePanel(ctk.CTkFrame):
             except (BrokenPipeError, OSError):
                 pass
 
-        # Stream child stdout/stderr line by line.  ``text=True`` universal
-        # newlines split ``\r``-delimited progress ticks into individual lines;
-        # we parse each as a progress update or emit it to the log pane.
+        # Stream child stdout/stderr line by line. Handle carriage-return style
+        # progress by keeping only the content after the last '\r' so the log
+        # pane does not accumulate intermediate bar states.
         assert proc.stdout is not None
         try:
             line: str
             for line in proc.stdout:
+                if "\r" in line:
+                    line = line.rsplit("\r", 1)[1]
                 stripped: str = line.rstrip()
                 if not stripped:
                     continue
-                # Check if this is a pbar progress line: [####--] N% phase
-                m: re.Match[str] | None = _PROGRESS_RE.match(stripped)
-                if m:
-                    pct: int = int(m.group(1))
-                    phase: str = m.group(2)
-                    self._log_queue.put(("__progress__", f"{pct}\t{phase}"))
-                    continue
-                # Not a progress line — classify and emit to the log pane.
                 lower: str = stripped.lower()
                 tag: str = ""
                 if lower.startswith(("\u2713", "done:", "complete:", "success:")):

--- a/mkpfs/gui/panels/base.py
+++ b/mkpfs/gui/panels/base.py
@@ -390,6 +390,8 @@ class BasePanel(ctk.CTkFrame):
                 proc.stdin.write("y\n")
                 proc.stdin.close()
             except (BrokenPipeError, OSError):
+                # Child already closed stdin (e.g. crashed before reading);
+                # nothing to recover — streaming will surface the error.
                 pass
 
         # Stream child stdout/stderr line by line through the log pane.

--- a/mkpfs/gui/panels/base.py
+++ b/mkpfs/gui/panels/base.py
@@ -1,16 +1,14 @@
 """Base panel class for the mkpfs GUI operation panels."""
 
-import builtins
-import contextlib
-import io
 import queue
+import subprocess
+import sys
 import threading
 from tkinter import filedialog
 from typing import Any
 
 import customtkinter as ctk
 
-from ... import pbar as _pbar
 from ..i18n import tr
 from ..theme import (
     _BG_CARD,
@@ -67,6 +65,7 @@ class BasePanel(ctk.CTkFrame):
         self._accent: str = _PANEL_ACCENT.get(self._panel_key, _NEON_BLUE)
         self._last_phase: str = ""
         self._last_progress: tuple[int, int] = (0, 0)
+        self._proc: subprocess.Popen | None = None
 
         # Header
         header: ctk.CTkFrame = ctk.CTkFrame(self, fg_color="transparent")
@@ -340,100 +339,88 @@ class BasePanel(ctk.CTkFrame):
         self._log_queue.put((tag, text))
 
     def _run_mkpfs(self, args: list[str]) -> None:
-        """Run mkpfs in-process and stream each output line to the log pane.
+        r"""Run mkpfs as a child process and stream each output line to the log pane.
 
-        Executes ``cli_mkpfs_main`` directly in the current Python interpreter
-        (the same one running the GUI) so no venv discovery or subprocess
-        spawning is required.  ``sys.stdout`` / ``sys.stderr`` are temporarily
-        redirected to a line-streaming helper that emits each line to the log
-        queue as it arrives.  ``builtins.input`` is patched to auto-confirm the
-        overwrite prompt with "y" so the GUI never blocks waiting for stdin.
+        The CLI runs in a separate process (``sys.executable --gui-subprocess …``)
+        rather than in-process so the GUI's drawing thread is never blocked by
+        long-running compression/multiprocessing work.  The spawned process handle
+        is stored on ``self._proc`` so a future stop button can call
+        ``terminate()``.
+
+        On Windows a console-window flash is suppressed via
+        ``CREATE_NO_WINDOW``.  ``stdin`` is fed ``"y\\n"`` so any
+        ``Overwrite? [Y/n]`` prompt is auto-confirmed (matching the previous
+        in-process ``builtins.input`` patch).  Progress-bar determinate mode is
+        not available across a process boundary; the log pane still shows all
+        output.
 
         Args:
-            args: CLI argument list passed verbatim to ``cli_mkpfs_main``.
+            args: CLI argument list passed verbatim to the CLI entrypoint.
         """
-        # Late import -- if mkpfs or its dependencies are missing the
-        # ImportError is caught below and shown as a readable error message.
-        try:
-            from mkpfs.cli import cli_mkpfs_main
-        except ImportError as exc:
-            self._emit(f"✗ Cannot import mkpfs: {exc}", "error")
-            self._emit("   Ensure cryptography is installed: uv sync", "muted")
-            return
-
         self._emit(f"$ mkpfs {' '.join(args)}", "muted")
 
-        # Line-streaming writer that forwards each line to the log queue.
-        emit: Any = self._emit
+        # Build the subprocess invocation.  ``--gui-subprocess`` tells the
+        # frozen entry point (mkpfs/gui/__main__.py) to route to the CLI instead
+        # of the GUI; everything after it is passed to ``cli_mkpfs_main``.
+        cmd: list[str] = [sys.executable, "--gui-subprocess", *args]
 
-        class _Streamer(io.TextIOBase):
-            def __init__(self, tag_fn: Any) -> None:
-                self._tag_fn: Any = tag_fn
-                self._buf: str = ""
+        # On Windows, suppress the console-window flash that subprocess.Popen
+        # would otherwise create for every operation (visible regression under
+        # a --windowed PyInstaller build).  Harmless on the frozen windowed exe;
+        # essential in dev mode where sys.executable is python.exe (console).
+        popen_kwargs: dict[str, Any] = {
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.STDOUT,
+            "stdin": subprocess.PIPE,
+            "text": True,
+        }
+        if sys.platform == "win32":
+            popen_kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
 
-            def write(self, s: str) -> int:
-                self._buf += s
-                # Process complete lines (delimited by \n). Within each line,
-                # \r means "overwrite the current line" so only the content
-                # after the last \r is kept — matching terminal semantics.
-                while "\n" in self._buf:
-                    line, self._buf = self._buf.split("\n", 1)
-                    # \r overwrites: keep only what's after the last \r
-                    if "\r" in line:
-                        line = line.rsplit("\r", 1)[1]
-                    stripped: str = line.rstrip()
-                    if not stripped:
-                        continue
-                    lower: str = stripped.lower()
-                    tag: str = ""
-                    # Match error prefix (❌ / ERROR ) not substring so "Errors: 0"
-                    # doesn't falsely set the failed flag on success.
-                    if lower.startswith(("\u2713", "done:", "complete:", "success:")):
-                        tag = "success"
-                    elif lower.startswith("error ") or "\u274c" in stripped:
-                        tag = "error"
-                    elif lower.startswith("warn ") or "\u26a0" in stripped:
-                        tag = "warning"
-                    self._tag_fn(stripped, tag)
-                return len(s)
-
-            def flush(self) -> None:
-                # Emit any remaining buffered content on flush so the final
-                # progress state appears in the log before completion.
-                if self._buf.strip():
-                    stripped: str = self._buf.rstrip()
-                    self._buf = ""
-                    lower: str = stripped.lower()
-                    tag: str = ""
-                    if lower.startswith(("\u2713", "done:", "complete:", "success:")):
-                        tag = "success"
-                    elif lower.startswith("error ") or "\u274c" in stripped:
-                        tag = "error"
-                    elif lower.startswith("warn ") or "\u26a0" in stripped:
-                        tag = "warning"
-                    self._tag_fn(stripped, tag)
-
-        streamer: _Streamer = _Streamer(emit)
-        original_input: Any = builtins.input
-        exit_code: int = 0
-
-        # Install a context-local default listener for this execution.
-        # Using a ContextVar avoids a global swap race between threads.
-        token = _pbar.default_listener.set(self._queued_progress)
-
-        # Auto-confirm any "Overwrite? [Y/n]" prompts from the CLI.
-        builtins.input = lambda _prompt="": "y"
         try:
-            with contextlib.redirect_stdout(streamer), contextlib.redirect_stderr(streamer):
-                exit_code = int(cli_mkpfs_main(args))
-        except SystemExit as exc:
-            exit_code = int(exc.code) if exc.code is not None else 0
-        except Exception as exc:
-            self._emit(f"✗ Unexpected error: {exc}", "error")
+            proc: subprocess.Popen = subprocess.Popen(cmd, **popen_kwargs)
+        except OSError as exc:
+            self._emit(f"✗ Failed to start mkpfs: {exc}", "error")
             return
+        self._proc = proc
+        # Auto-confirm any "Overwrite? [Y/n]" prompt from the CLI by piping
+        # "y\n" to the child's stdin, then close it so the child sees EOF.
+        if proc.stdin is not None:
+            try:
+                proc.stdin.write("y\n")
+                proc.stdin.close()
+            except (BrokenPipeError, OSError):
+                pass
+
+        # Stream child stdout/stderr line by line through the log pane.
+        assert proc.stdout is not None
+        try:
+            line: str
+            for line in proc.stdout:
+                # ``\r`` overwrites: keep only the content after the last ``\r``
+                # (terminal progress semantics) so the log pane doesn't
+                # accumulate incremental progress bars.
+                if "\r" in line:
+                    line = line.rsplit("\r", 1)[1]
+                stripped: str = line.rstrip()
+                if not stripped:
+                    continue
+                lower: str = stripped.lower()
+                tag: str = ""
+                # Match error prefix (❌ / ERROR ) not substring so "Errors: 0"
+                # doesn't falsely set the failed flag on success.
+                if lower.startswith(("\u2713", "done:", "complete:", "success:")):
+                    tag = "success"
+                elif lower.startswith("error ") or "\u274c" in stripped:
+                    tag = "error"
+                elif lower.startswith("warn ") or "\u26a0" in stripped:
+                    tag = "warning"
+                self._emit(stripped, tag)
         finally:
-            builtins.input = original_input
-            _pbar.default_listener.reset(token)
+            proc.wait()
+            self._proc = None
+
+        exit_code: int = int(proc.returncode or 0)
         self._emit("", "")
         if exit_code == 0:
             self._emit(tr("ok"), "success")

--- a/mkpfs/gui/panels/base.py
+++ b/mkpfs/gui/panels/base.py
@@ -1,6 +1,7 @@
 """Base panel class for the mkpfs GUI operation panels."""
 
 import queue
+import re
 import subprocess
 import sys
 import threading
@@ -20,24 +21,11 @@ from ..theme import (
 )
 from ..widgets import GlassCard, LogPane, NeonButton, SectionLabel
 
-
 # ---------------------------------------------------------------------------
 # Panel base class
 # ---------------------------------------------------------------------------
-class QueuedProgress:
-    """Adapter that forwards progress events to a queue for UI-thread polling.
-
-    Wired as ``default_listener`` so **every** Progress instance created during
-    an in-process build automatically pushes progress/status tuples to the
-    queue.  The panel's ``_poll_log_queue`` drains the queue and updates the
-    progress bar / phase label on the UI thread.
-    """
-
-    def __init__(self, q: queue.Queue) -> None:
-        self._q = q
-
-    def __call__(self, action: str, *args: Any) -> None:
-        self._q.put_nowait((action, *args))
+# Matches pbar.py progress lines: [##########----------] N% phase
+_PROGRESS_RE: re.Pattern[str] = re.compile(r"^\[[#-]+\]\s*(\d+)%\s*(\S+)")
 
 
 class BasePanel(ctk.CTkFrame):
@@ -115,11 +103,6 @@ class BasePanel(ctk.CTkFrame):
         )
         self._phase_label.pack(anchor="w", padx=26, pady=(0, 4))
 
-        # Progress event queue — QueuedProgress is registered as the module-level
-        # listener so every background-phase Progress.step() / status() call
-        # pushes structured tuples here instead of writing \r-delimited stderr.
-        self._progress_queue: queue.Queue = queue.Queue()
-        self._queued_progress: QueuedProgress = QueuedProgress(self._progress_queue)
         self._progress.stop()
         self._progress.set(0)
 
@@ -216,14 +199,25 @@ class BasePanel(ctk.CTkFrame):
 
     def _poll_log_queue(self) -> None:
         """Drain the log queue and update the UI; reschedules itself."""
-        # Drain progress events (pbar listener)
-        self._drain_progress_events()
-
         # Drain log messages
         try:
             while True:
                 tag, text = self._log_queue.get_nowait()
-                if tag == "error":
+                if tag == "__progress__":
+                    # Progress update from subprocess: format "pct\tphase"
+                    parts: list[str] = text.split("\t", 1)
+                    pct: int = int(parts[0]) if parts and parts[0] else 0
+                    phase: str = parts[1] if len(parts) > 1 else ""
+                    if self._progress.cget("mode") != "determinate":
+                        self._progress.stop()
+                        self._progress.configure(mode="determinate")
+                        self._progress.set(0)
+                    self._progress.set(max(0.0, min(1.0, pct / 100.0)))
+                    if phase:
+                        self._phase_label.configure(text=phase)
+                    self._last_phase = phase
+                    self._last_progress = (pct, 100)
+                elif tag == "error":
                     self._failed = True
                     self._log.append(text, tag)
                 elif tag == "__done__":
@@ -268,42 +262,6 @@ class BasePanel(ctk.CTkFrame):
             pass
         self.after(80, self._poll_log_queue)
 
-    def _drain_progress_events(self) -> None:
-        """Drain progress events from the progress queue and update widgets."""
-        try:
-            while True:
-                action, *args = self._progress_queue.get_nowait()
-                if action == "step":
-                    phase_name, done, total, _bytes_processed = args
-                    # Emit a log line when a phase completes (done reaches total)
-                    # or when the phase changes to a new one.
-                    if phase_name != self._last_phase and self._last_phase:
-                        prev_done, prev_total = self._last_progress
-                        pct: int = int(prev_done / prev_total * 100) if prev_total > 0 else 100
-                        self._emit(f"✓ {self._last_phase}: {pct}%", "success")
-                    self._last_phase = phase_name
-                    self._last_progress = (done, total)
-                    # Switch to determinate mode on first progress event
-                    if self._progress.cget("mode") != "determinate":
-                        self._progress.stop()
-                        self._progress.configure(mode="determinate")
-                        self._progress.set(0)
-                    if total > 0:
-                        ratio = done / total
-                    else:
-                        ratio = 0.0
-                    # Clamp ratio to [0.0, 1.0] to guard against out-of-range listener values
-                    ratio = max(0.0, min(1.0, ratio))
-                    self._progress.set(ratio)
-                    # Update phase label with the current operation name
-                    if phase_name:
-                        self._phase_label.configure(text=phase_name)
-                elif action == "status":
-                    (message,) = args
-                    self._phase_label.configure(text=message.strip())
-        except queue.Empty:
-            pass
-
     def _on_export_log(self) -> None:
         """Open a save dialog and write the current log content to a file."""
         import json as _json
@@ -341,38 +299,44 @@ class BasePanel(ctk.CTkFrame):
     def _run_mkpfs(self, args: list[str]) -> None:
         r"""Run mkpfs as a child process and stream each output line to the log pane.
 
-        The CLI runs in a separate process (``sys.executable --gui-subprocess …``)
-        rather than in-process so the GUI's drawing thread is never blocked by
-        long-running compression/multiprocessing work.  The spawned process handle
-        is stored on ``self._proc`` so a future stop button can call
-        ``terminate()``.
+        The CLI runs in a separate process so the GUI's drawing thread is never
+        blocked by long-running compression/multiprocessing work.  The spawned
+        process handle is stored on ``self._proc`` so a future stop button can
+        call ``terminate()``.
+
+        Progress lines from ``pbar.py`` (``\r``-delimited ``[bar] N% phase``
+        updates) are parsed and forwarded to the UI thread as ``__progress__``
+        events so the determinate progress bar tracks real progress.  Other
+        output lines are emitted to the log pane as usual.
 
         On Windows a console-window flash is suppressed via
-        ``CREATE_NO_WINDOW``.  ``stdin`` is fed ``"y\\n"`` so any
-        ``Overwrite? [Y/n]`` prompt is auto-confirmed (matching the previous
-        in-process ``builtins.input`` patch).  Progress-bar determinate mode is
-        not available across a process boundary; the log pane still shows all
-        output.
+        ``CREATE_NO_WINDOW``.  ``stdin`` is fed ``"y\n"`` so any
+        ``Overwrite? [Y/n]`` prompt is auto-confirmed.
 
         Args:
             args: CLI argument list passed verbatim to the CLI entrypoint.
         """
         self._emit(f"$ mkpfs {' '.join(args)}", "muted")
 
-        # Build the subprocess invocation.  ``--gui-subprocess`` tells the
-        # frozen entry point (mkpfs/gui/__main__.py) to route to the CLI instead
-        # of the GUI; everything after it is passed to ``cli_mkpfs_main``.
-        cmd: list[str] = [sys.executable, "--gui-subprocess", *args]
+        # Build the subprocess invocation.  In a frozen PyInstaller binary
+        # ``sys.executable`` is the binary itself and ``--gui-subprocess`` lands
+        # in ``sys.argv``; in dev mode ``sys.executable`` is the interpreter and
+        # we route through ``-m mkpfs.gui`` to hit ``__main__.py``.
+        if getattr(sys, "frozen", False):
+            cmd: list[str] = [sys.executable, "--gui-subprocess", *args]
+        else:
+            cmd = [sys.executable, "-m", "mkpfs.gui", "--gui-subprocess", *args]
 
-        # On Windows, suppress the console-window flash that subprocess.Popen
-        # would otherwise create for every operation (visible regression under
-        # a --windowed PyInstaller build).  Harmless on the frozen windowed exe;
-        # essential in dev mode where sys.executable is python.exe (console).
+        # ``text=True`` enables universal newlines (``\r`` → ``\n``) so each
+        # progress-bar tick becomes its own line.  ``encoding="utf-8"`` ensures
+        # non-ASCII output decodes cleanly on all platforms.
         popen_kwargs: dict[str, Any] = {
             "stdout": subprocess.PIPE,
             "stderr": subprocess.STDOUT,
             "stdin": subprocess.PIPE,
             "text": True,
+            "encoding": "utf-8",
+            "errors": "replace",
         }
         if sys.platform == "win32":
             popen_kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
@@ -380,9 +344,10 @@ class BasePanel(ctk.CTkFrame):
         try:
             proc: subprocess.Popen = subprocess.Popen(cmd, **popen_kwargs)
         except OSError as exc:
-            self._emit(f"✗ Failed to start mkpfs: {exc}", "error")
+            self._emit(f"\u2717 Failed to start mkpfs: {exc}", "error")
             return
         self._proc = proc
+
         # Auto-confirm any "Overwrite? [Y/n]" prompt from the CLI by piping
         # "y\n" to the child's stdin, then close it so the child sees EOF.
         if proc.stdin is not None:
@@ -390,27 +355,28 @@ class BasePanel(ctk.CTkFrame):
                 proc.stdin.write("y\n")
                 proc.stdin.close()
             except (BrokenPipeError, OSError):
-                # Child already closed stdin (e.g. crashed before reading);
-                # nothing to recover — streaming will surface the error.
                 pass
 
-        # Stream child stdout/stderr line by line through the log pane.
+        # Stream child stdout/stderr line by line.  ``text=True`` universal
+        # newlines split ``\r``-delimited progress ticks into individual lines;
+        # we parse each as a progress update or emit it to the log pane.
         assert proc.stdout is not None
         try:
             line: str
             for line in proc.stdout:
-                # ``\r`` overwrites: keep only the content after the last ``\r``
-                # (terminal progress semantics) so the log pane doesn't
-                # accumulate incremental progress bars.
-                if "\r" in line:
-                    line = line.rsplit("\r", 1)[1]
                 stripped: str = line.rstrip()
                 if not stripped:
                     continue
+                # Check if this is a pbar progress line: [####--] N% phase
+                m: re.Match[str] | None = _PROGRESS_RE.match(stripped)
+                if m:
+                    pct: int = int(m.group(1))
+                    phase: str = m.group(2)
+                    self._log_queue.put(("__progress__", f"{pct}\t{phase}"))
+                    continue
+                # Not a progress line — classify and emit to the log pane.
                 lower: str = stripped.lower()
                 tag: str = ""
-                # Match error prefix (❌ / ERROR ) not substring so "Errors: 0"
-                # doesn't falsely set the failed flag on success.
                 if lower.startswith(("\u2713", "done:", "complete:", "success:")):
                     tag = "success"
                 elif lower.startswith("error ") or "\u274c" in stripped:

--- a/mkpfs/logging.py
+++ b/mkpfs/logging.py
@@ -11,6 +11,25 @@ import logging
 import os
 import sys
 
+# Icon maps kept at module scope so fallback logic can force ASCII without
+# consulting `supports_utf8()` again during error handling.
+UTF8_ICON_MAP: dict[str, str] = {
+    "info": "ℹ️",
+    "ok": "✅",
+    "warning": "⚠️",
+    "error": "❌",
+    "file": "📄",
+    "success": "🎉",
+}
+ASCII_ICON_MAP: dict[str, str] = {
+    "info": "INFO",
+    "ok": "OK",
+    "warning": "WARN",
+    "error": "ERROR",
+    "file": "FILE",
+    "success": "SUCCESS",
+}
+
 
 def supports_utf8() -> bool:
     """Return True when terminal appears to support UTF-8 icons.
@@ -29,17 +48,8 @@ def supports_utf8() -> bool:
 
 def icon(name: str | None) -> str:
     """Map a semantic icon name to a UTF-8 glyph or an ASCII fallback."""
-    utf8: dict[str, str] = {"info": "ℹ️", "ok": "✅", "warning": "⚠️", "error": "❌", "file": "📄", "success": "🎉"}
-    ascii_map: dict[str, str] = {
-        "info": "INFO",
-        "ok": "OK",
-        "warning": "WARN",
-        "error": "ERROR",
-        "file": "FILE",
-        "success": "SUCCESS",
-    }
     name_key: str = name or ""
-    return utf8.get(name_key, "") if supports_utf8() else ascii_map.get(name_key, "")
+    return UTF8_ICON_MAP.get(name_key, "") if supports_utf8() else ASCII_ICON_MAP.get(name_key, "")
 
 
 def log(message: str, level: int = logging.INFO, icon_name: str | None = None) -> None:
@@ -77,10 +87,15 @@ def log(message: str, level: int = logging.INFO, icon_name: str | None = None) -
             color_code = ""
 
     colored_text: str = f"{color_code}{text}{reset_code}" if color_code else text
-    if level >= logging.ERROR:
-        print(colored_text, file=sys.stderr)
-    else:
-        print(colored_text, file=sys.stdout)
+    stream = sys.stderr if level >= logging.ERROR else sys.stdout
+    try:
+        print(colored_text, file=stream)
+    except UnicodeEncodeError:
+        # Fall back to ASCII-only icon + ASCII-safe message when the stream codec
+        # (e.g. cp1252 on Windows pipes) cannot encode the original text.
+        ascii_prefix: str = (ASCII_ICON_MAP.get(icon_name or "", "") + " ") if icon_name else ""
+        ascii_message: str = str(message).encode("ascii", "replace").decode()
+        print(ascii_prefix + ascii_message, file=stream)
 
 
 def info(message: str, icon_name: str | None = None) -> None:

--- a/tests/mkpfs/test_logging.py
+++ b/tests/mkpfs/test_logging.py
@@ -42,3 +42,66 @@ class TestLoggingHelpers(unittest.TestCase):
 
         self.assertIn("hello world", stdout_buffer.getvalue())
         self.assertIn("bad stuff", stderr_buffer.getvalue())
+
+    def test_log_falls_back_when_stream_rejects_message_body_unicode(self) -> None:
+        """If the stream codec rejects non-ASCII in the message body, log() should print an ASCII-safe fallback."""
+
+        class FailingStdout:
+            encoding: str = "cp1252"  # simulate Windows pipe
+
+            def __init__(self) -> None:
+                self.data: str = ""
+
+            def write(self, s: str) -> int:
+                # Reject any non-ASCII bytes (simulate cp1252 failure on emoji)
+                if any(ord(ch) > 0x7F for ch in s):
+                    raise UnicodeEncodeError("cp1252", s, 0, 1, "non-ASCII not encodable")
+                self.data += s
+                return len(s)
+
+            def flush(self) -> None:  # pragma: no cover - noop
+                return
+
+            def isatty(self) -> bool:  # pragma: no cover
+                return False
+
+        fake = FailingStdout()
+        with patch.object(sys, "stdout", fake):
+            # Emoji in the message body should trigger the fallback
+            mlogging.info("🎉 done", icon_name=None)
+        # Fallback should have printed ASCII-safe content containing the message text
+        self.assertIn("done", fake.data)
+        # Ensure no raw emoji slipped through
+        self.assertNotIn("🎉", fake.data)
+
+    def test_log_falls_back_when_icon_glyph_rejected_despite_utf8_claim(self) -> None:
+        """If stdout claims UTF-8 but rejects glyphs at write(), log() must fall back to ASCII icon."""
+
+        class LyingStdout:
+            # Report UTF-8 to make supports_utf8() return True
+            encoding: str = "utf-8"
+
+            def __init__(self) -> None:
+                self.data: str = ""
+
+            def write(self, s: str) -> int:
+                # Reject any non-ASCII to simulate downstream cp1252 pipe
+                if any(ord(ch) > 0x7F for ch in s):
+                    raise UnicodeEncodeError("cp1252", s, 0, 1, "non-ASCII not encodable")
+                self.data += s
+                return len(s)
+
+            def flush(self) -> None:  # pragma: no cover - noop
+                return
+
+            def isatty(self) -> bool:  # pragma: no cover
+                return False
+
+        fake = LyingStdout()
+        with patch.object(sys, "stdout", fake), patch.dict("os.environ", {}, clear=True):
+            mlogging.info("done", icon_name="success")
+        # Fallback should have switched the icon to ASCII and preserved message text
+        self.assertIn("SUCCESS", fake.data)
+        self.assertIn("done", fake.data)
+        # No raw emoji should be present
+        self.assertNotIn("🎉", fake.data)


### PR DESCRIPTION
# Fix Windows crash on GUI success logs

## 🤔 Why?
On Windows, the GUI runs the CLI as a subprocess and pipes its stdout. Those pipes often use the system ANSI code page (e.g., cp1252). When a success message includes a non‑ASCII glyph (like an emoji), `print()` can raise `UnicodeEncodeError`, causing the GUI to report a failure even though the image was written successfully. See #122.

## 🔧 What changed
- Catch `UnicodeEncodeError` in `logging.log()` and retry with an ASCII‑only fallback (sanitized text and ASCII icon when provided).
- Ensure the GUI subprocess entry point reconfigures `stdout`/`stderr` to UTF‑8 with `errors="replace"` when available (guarded with `contextlib.suppress`).
- Add unit tests that simulate Windows pipes rejecting non‑ASCII both in the message body and in the icon path.

## 🧪 How to test
- Run unit tests: `pytest tests/mkpfs/test_logging.py`.
- Manual (Windows): pack a single file to FFPFS via the GUI. Expect a success message without a crash even on non‑UTF‑8 systems; message will use ASCII when needed.

Closes #122.
