### PR TITLE
Stop coverage upload on tag builds; prevent release edit cancels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ permissions:
   contents: read
   code-quality: write
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 on:
   push:
@@ -16,7 +16,7 @@ on:
     branches:
       - '**'
   release:
-    types: [published, prereleased, created, edited]
+    types: [published, prereleased]
 jobs:
   build:
     name: 📦 Builds the Python package
@@ -42,12 +42,13 @@ jobs:
       - name: Run tests
         run: SKIP_VENV=1 ./run-tests.sh
       - name: Upload coverage report
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && !startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-code-coverage@v1
         with:
           file: coverage.xml
           language: Python
           label: code-coverage/pytest
+          fail-on-error: false
       - name: Format
         run: uvx ruff format . --check --diff
       - name: Lint
@@ -468,7 +469,7 @@ jobs:
 
   virustotal-scan:
     name: 🔒 VirusTotal scan release assets
-    if: github.event_name == 'release' && (github.event.action == 'created' || github.event.action == 'prereleased')
+    if: github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'prereleased')
     needs:
       - attach-to-release
     runs-on: ubuntu-latest

--- a/mkpfs/gui/panels/pack_file.py
+++ b/mkpfs/gui/panels/pack_file.py
@@ -44,9 +44,7 @@ class PackFilePanel(BasePanel):
         self._metadata_preview.grid(row=0, column=0, columnspan=2, sticky="ew")
         self._metadata_preview.load(self._src.get().strip())
 
-        ctk.CTkFrame(card, height=1, fg_color=_BORDER_BRIGHT).grid(
-            row=1, column=0, columnspan=2, sticky="ew", padx=16
-        )
+        ctk.CTkFrame(card, height=1, fg_color=_BORDER_BRIGHT).grid(row=1, column=0, columnspan=2, sticky="ew", padx=16)
 
         SectionLabel(card, tr("paths"), color=self._accent).grid(
             row=2, column=0, columnspan=2, sticky="w", padx=16, pady=(12, 6)

--- a/tests/mkpfs/test_game_metadata.py
+++ b/tests/mkpfs/test_game_metadata.py
@@ -118,9 +118,9 @@ def test_unknown_file_uses_safe_fallbacks(tmp_path: Path) -> None:
 def test_reads_ffpkg_title_and_apr_emu_from_header_regions(tmp_path: Path) -> None:
     path = tmp_path / "game.ffpkg"
     data = bytearray(0x39000)
-    data[0xFFEC : 0xFFF0] = b"\x19\x01\x54\x19"
+    data[0xFFEC:0xFFF0] = b"\x19\x01\x54\x19"
     name = b"PPSA54321.complete"
-    data[0x38000 : 0x38008] = b"\x01\x00\x00\x00\x20\x00\x01" + bytes([len(name)])
+    data[0x38000:0x38008] = b"\x01\x00\x00\x00\x20\x00\x01" + bytes([len(name)])
     data[0x38008 : 0x38008 + len(name)] = name
     data[0x20000 : 0x20000 + len(b"fakelib/libSceAmpr.sprx")] = b"fakelib/libSceAmpr.sprx"
     path.write_bytes(data)


### PR DESCRIPTION
# Stop coverage upload on tag builds; prevent release edit cancels

## 🤔 Why?
- Tag builds failed on coverage upload: service rejects `refs/tags/*`.
- Editing a release cancelled running builds sharing same `refs/tags/<ver>` due to concurrency group.
- VirusTotal scan skipped on published releases after trigger tweak.

## 🔧 What changed
- Coverage step: add `!startsWith(github.ref, 'refs/tags/')` guard; keep PR fork safety; make failures non-blocking (`fail-on-error: false`).
- Concurrency: include `github.event_name` in group to avoid push-tag vs release cancellation.
- Release triggers: drop `edited`/`created` to avoid rebuilds on note edits.
- VirusTotal: run on `published` and `prereleased` actions.

## 🧪 How to test
- Create lightweight tag on a temporary branch; CI should pass and skip coverage upload on tag.
- Publish a prerelease; ensure builds complete, VirusTotal step runs, no cancellation when editing notes.

## 💬 Notes
- Build may still run on both tag push and release event; artifacts attach from release run. If single run preferred, follow-up can gate `build` on `github.event_name != 'release'`.
