### PR TITLE
Add Windows VERSIONINFO metadata and disable UPX to reduce AV false positives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,11 @@ jobs:
           VERSION_FILE="dist/version_info.txt"
           VER="${VERSION:-0.0.0}"
           VER_SHORT="${VERSION_SHORT:-${VER%%-*}}"
+          # strip leading tag prefix v/V if present (e.g., v1.2.3 -> 1.2.3)
+          case "$VER_SHORT" in
+            v*) VER_SHORT="${VER_SHORT#v}" ;;
+            V*) VER_SHORT="${VER_SHORT#V}" ;;
+          esac
           IFS='.' read -r MAJ MIN PAT <<<"${VER_SHORT}"
           : "${MAJ:=0}"; : "${MIN:=0}"; : "${PAT:=0}"
           FILE_TUPLE="${MAJ}, ${MIN}, ${PAT}, 0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,22 @@ jobs:
         shell: bash
         run: |
           SITE_PACKAGES="$PWD/.venv/Lib/site-packages"
+          # Build VERSIONINFO from template with real version to reduce AV heuristics
+          mkdir -p dist
+          VERSION_FILE="dist/version_info.txt"
+          VER="${VERSION:-0.0.0}"
+          VER_SHORT="${VERSION_SHORT:-${VER%%-*}}"
+          IFS='.' read -r MAJ MIN PAT <<<"${VER_SHORT}"
+          : "${MAJ:=0}"; : "${MIN:=0}"; : "${PAT:=0}"
+          FILE_TUPLE="${MAJ}, ${MIN}, ${PAT}, 0"
+          PROD_STR="${MAJ}.${MIN}.${PAT}.0"
+          YEAR="$(date +%Y)"
+          DATE_ISO="$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S')"
+          sed -e "s/__FILE_VERSION_TUPLE__/${FILE_TUPLE}/g" \
+              -e "s/__PRODUCT_VERSION_STR__/${PROD_STR}/g" \
+              -e "s/__YEAR__/${YEAR}/g" \
+              -e "s/__DATE__/${DATE_ISO}/g" \
+              scripts/version_info.txt > "$VERSION_FILE"
 
           uvx pyinstaller \
             --noconfirm \
@@ -174,6 +190,8 @@ jobs:
             --paths "$SITE_PACKAGES" \
             --name MkPFS \
             --icon dist/icon.ico \
+            --version-file "$VERSION_FILE" \
+            --noupx \
             --collect-all customtkinter \
             --collect-submodules customtkinter \
             --collect-all PIL \

--- a/scripts/version_info.txt
+++ b/scripts/version_info.txt
@@ -1,0 +1,37 @@
+# PyInstaller version file for Windows PE VERSIONINFO resource
+# Encoding: UTF-8
+# Docs: https://pyinstaller.org/en/stable/usage.html#version-file
+
+VSVersionInfo(
+  ffi=FixedFileInfo(
+    filevers=(__FILE_VERSION_TUPLE__),
+    prodvers=(__FILE_VERSION_TUPLE__),
+    mask=0x3f,
+    flags=0x0,
+    OS=0x40004,
+    fileType=0x1,
+    subtype=0x0,
+    date=(0, 0)
+  ),
+  kids=[
+    StringFileInfo([
+      StringTable(
+        '040904B0',
+        [
+          StringStruct('CompanyName', 'PSBrew'),
+          StringStruct('FileDescription', 'MkPFS — PlayStation File System packer (GUI)'),
+          StringStruct('FileVersion', '__PRODUCT_VERSION_STR__'),
+          StringStruct('InternalName', 'MkPFS'),
+          StringStruct('LegalCopyright', '© __YEAR__ PSBrew. All rights reserved.'),
+          StringStruct('OriginalFilename', 'MkPFS.exe'),
+          StringStruct('ProductName', 'MkPFS'),
+          StringStruct('ProductVersion', '__PRODUCT_VERSION_STR__'),
+          StringStruct('Comments', 'Built by GitHub Actions CI for PSBrew/MkPFS on __DATE__')
+        ]
+      )
+    ]),
+    VarFileInfo([
+      VarStruct('Translation', [1033, 1200])
+    ])
+  ]
+)


### PR DESCRIPTION
# 🤔 Why?
Some Windows antivirus engines flagged our PyInstaller onefile `.exe` as malware (e.g., Microsoft Wacatac.B!ml). Heuristics penalize unsigned, metadata-less stubs and self-extracting packers.

## 🔧 What changed
- Add a VERSIONINFO resource to the Windows build via a templated `scripts/version_info.txt` populated at CI time (CompanyName, ProductName, FileVersion/ProductVersion, copyright, build date).
- Pass `--version-file` to PyInstaller so the PE carries proper metadata.
- Add `--noupx` to avoid any packer signatures that increase detections.
- Keep artifact naming and build matrix unchanged.

## 🧪 How to test
- Trigger Windows binary build in CI and inspect the resulting `.exe` VERSIONINFO (e.g., `sigcheck`, `Resource Hacker`).
- Re-run VirusTotal scan on the release artifacts; expect fewer or zero heuristic flags for Microsoft and peers.

## 💬 Notes
- Further mitigation (optional): also publish an `--onedir` zip alongside the onefile `.exe`, or code-sign the binary if a certificate becomes available.
